### PR TITLE
Remove exceptions for repaired test drivers

### DIFF
--- a/tools/test_filter.py
+++ b/tools/test_filter.py
@@ -1,5 +1,4 @@
 {
-    'bslmf_addreference': [ {'OS': 'Windows'} ],
     'bslstl_iteratorutil': [ {'OS': 'SunOS'} ],
     'bslstl_unorderedmultiset': [ {'OS': 'SunOS'} ],
     'bsls_atomic' : [


### PR DESCRIPTION
... including:
- bslalg_constructorproxy on AIX shared library builds:
  Test drivers that override std::new now build correctly in shared library versions on AIX, so no exception is needed now for the bslalg_constructorproxy test driver.
- bslmf_addreference on Windows:
  Test driver has been fixed as part of recent updates to the type traits system.
