### PR TITLE
bsls_timeutil: Fix OS_DARWIN compilation.

### DIFF
--- a/groups/bsl/bsls/bsls_timeutil.cpp
+++ b/groups/bsl/bsls/bsls_timeutil.cpp
@@ -21,8 +21,9 @@ BSLS_IDENT("$Id$ $CSID$")
     #error "Don't know how to get nanosecond time for this platform"
 #endif
 
-#if defined(BSLS_PLATFORM_OS_SOLARIS) || defined(BSLS_PLATFORM_OS_HPUX)
-    #include <sys/time.h>  // gethrtime()
+#if defined(BSLS_PLATFORM_OS_UNIX) && \
+    !(defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_AIX))
+    #include <sys/time.h>  // gethrtime(), gettimeofday()
 #endif
 
 namespace BloombergLP {


### PR DESCRIPTION
Fixes sys/time.h ifdef logic to include all OS_UNIX other than
OS_LINUX and OS_AIX.  Adds cast to ::times() clock_t return value
due to value being unsigned on OS_DARWIN.

Addresses issue reported in #5.
