### PR TITLE
bsls_timeutil: Add clock_t static_cast.

### DIFF
--- a/groups/bsl/bsls/bsls_timeutil.cpp
+++ b/groups/bsl/bsls/bsls_timeutil.cpp
@@ -74,7 +74,7 @@ void UnixTimerUtil::systemProcessTimers(clock_t *systemTimer,
                                         clock_t *userTimer)
 {
     struct tms processTimes;
-    if (-1 == ::times(&processTimes)) {
+    if (static_cast<clock_t>(-1) == ::times(&processTimes)) {
         *systemTimer = 0;
         *userTimer   = 0;
         return;                                                       // RETURN


### PR DESCRIPTION
Add static_cast<clock_t> to ::times return value to silence compiler warning
on OS_DARWIN due to clock_t being unsigned.
