### PR TITLE
Issue #10: Support pointer to member in bsl::pair

### DIFF
--- a/groups/bsl/bslstl/bslstl_pair.h
+++ b/groups/bsl/bslstl/bslstl_pair.h
@@ -439,7 +439,7 @@ struct Pair_Imp<T1, T2, 1, 1> {
                         // ==========
 
 template <typename T1, typename T2>
-class pair : private Pair_Imp<T1, T2,
+class pair : public Pair_Imp<T1, T2,
                              BloombergLP::bslma::UsesBslmaAllocator<T1>::value,
                              BloombergLP::bslma::UsesBslmaAllocator<T2>::value>
 {

--- a/groups/bsl/bslstl/bslstl_pair.t.cpp
+++ b/groups/bsl/bslstl/bslstl_pair.t.cpp
@@ -67,6 +67,7 @@ using namespace BloombergLP;
 //     pair(const pair<U1, U2>& rhs, bslma::Allocator *alloc);
 // [5] void pair::swap(pair& rhs);
 // [5] void swap(pair& lhs, pair& rhs);
+// [7] Pointer to member test
 //-----------------------------------------------------------------------------
 // [1] BREATHING TEST
 // [6] USAGE EXAMPLE
@@ -610,6 +611,31 @@ int main(int argc, char *argv[])
     std::printf("TEST " __FILE__ " CASE %d\n", test);
 
     switch (test) { case 0:  // Zero is always the leading case.
+      case 7: {
+        // --------------------------------------------------------------------
+        // Pointer to member
+        //
+        // Concerns:
+        // - We can use pointer to members to access both 'first' and 'second'
+        //
+        // Plan
+        // - Create pointer to member to both 'first' and 'second' and check
+        //   that the behavior is as expected
+        //
+        // Testing:
+        //     Usage Example
+        // --------------------------------------------------------------------
+        if (verbose) std::printf("\nPOINTER TO MEMBER TEST"
+                                 "\n======================\n");
+
+        int bsl::pair<int,const char*>::*pfirst
+                                        = &bsl::pair<int,const char*>::first;
+        const char* bsl::pair<int,const char*>::*psecond
+                                        = &bsl::pair<int,const char*>::second;
+        bsl::pair<int,const char*> p(10, "test7");
+        ASSERT(p.first == (p.*pfirst));
+        ASSERT(p.second == (p.*psecond));
+      } break;
       case 6: {
         // --------------------------------------------------------------------
         // USAGE EXAMPLE


### PR DESCRIPTION
- groups/bsl/bslstl/bslstl_pair.h
  Change inheritance from bsl::Pair_Imp from private to public.
  Although the inheritance is an implementation detail and thus
  should be private, private inheritance inhibits the use of
  pointer to member to the base.
