### PR TITLE
bslalg_dequeprimitives.t: Fix -Wformat warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp
+++ b/groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp
@@ -133,7 +133,7 @@ namespace {
                     printf(" bslma::EXCEPTION:"                            \
                            " alloc limit = %d,"                            \
                            " last alloc size = %d\n",                      \
-                           bslmaExceptionCounter, e.numBytes());           \
+                           bslmaExceptionCounter, (int) e.numBytes());     \
                 }                                                          \
                 else if (0 == bslmaExceptionLimit) {                       \
                     printf(" [ Note: 'bslmaExceptionLimit' reached. ]\n"); \


### PR DESCRIPTION
Fixes pages and pages of these:

```
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp: In function ‘void testInsertAndMoveToFrontRange(bool) [with TYPE = TestTypeNoAlloc, int BLOCK_LENGTH = 1]’:
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:2137:   instantiated from here
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:924: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘ptrdiff_t’ [-Wformat]
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:924: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘ptrdiff_t’ [-Wformat]
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp: In function ‘void testInsertAndMoveToFrontRange(bool) [with TYPE = TestTypeNoAlloc, int BLOCK_LENGTH = 2]’:
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:2138:   instantiated from here
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:924: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘ptrdiff_t’ [-Wformat]
../groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp:924: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘ptrdiff_t’ [-Wformat]
...
```
