### PR TITLE
bslalg_hashtableanchor.t: Fix -Wunused warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_hashtableanchor.t.cpp
+++ b/groups/bsl/bslalg/bslalg_hashtableanchor.t.cpp
@@ -16,6 +16,7 @@
 
 #include <bslmf_assert.h>
 
+#include <bsls_annotation.h>
 #include <bsls_assert.h>
 #include <bsls_asserttest.h>
 #include <bsls_platform.h>
@@ -498,10 +499,8 @@ bool PtrHashSet::insert(void *ptr)
 
     if (bucketArraySize() * d_maxLoadFactor < d_numNodes + 1) {
         grow();
-#ifdef BSLS_ASSERT_SAFE_IS_ACTIVE
-        bool found = find(&insertionPoint, &bucket, ptr);
+        bool found BSLS_ANNOTATION_UNUSED = find(&insertionPoint, &bucket, ptr);
         BSLS_ASSERT_SAFE(!found);
-#endif
     }
 
     ++d_numNodes;


### PR DESCRIPTION
Fixes the following:

```
../groups/bsl/bslalg/bslalg_hashtableanchor.t.cpp: In member function ‘bool PtrHashSet::insert(void*)’:
../groups/bsl/bslalg/bslalg_hashtableanchor.t.cpp:501: warning: unused variable ‘found’ [-Wunused-variable]
```

The `found` variables is only referenced in `BSLS_ASSERT_SAFE`, so put the block in a `BSLS_ASSERT_SAFE_IS_ACTIVE` check.
