### PR TITLE
bslalg_hashtableimputil.t: Fix -Wformat warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_hashtableimputil.t.cpp
+++ b/groups/bsl/bslalg/bslalg_hashtableimputil.t.cpp
@@ -272,7 +272,7 @@ void debugPrint(const HashTableAnchor& anchor)
     }
     else {
         for (size_t n = 0; n < anchor.bucketArraySize(); ++n) {
-            printf("\nBucket [%d]: ", n);
+            printf("\nBucket [%d]: ", (int) n);
             const HashTableBucket& bucket = anchor.bucketArrayAddress()[n];
             if (!bucket.first()) {
                 continue;


### PR DESCRIPTION
Fixes the following:

```
../groups/bsl/bslalg/bslalg_hashtableimputil.t.cpp: In function ‘void debugPrint(const BloombergLP::bslalg::HashTableAnchor&)’:
../groups/bsl/bslalg/bslalg_hashtableimputil.t.cpp:275: warning: format ‘%d’ expects type ‘int’, but argument 2 has type ‘size_t’ [-Wformat]
../groups/bsl/bslalg/bslalg_hashtableimputil.t.cpp:275: warning: format ‘%d’ expects type ‘int’, but argument 2 has type ‘size_t’ [-Wformat]
```
