### PR TITLE
bslalg_rangecompare.t: Fix various warnings.

### DIFF
--- a/groups/bsl/bslalg/bslalg_rangecompare.t.cpp
+++ b/groups/bsl/bslalg/bslalg_rangecompare.t.cpp
@@ -5,6 +5,7 @@
 #include <bslmf_isbitwiseequalitycomparable.h>          // for testing only
 #include <bslma_usesbslmaallocator.h>                   // for testing only
 #include <bslmf_nestedtraitdeclaration.h>               // for testing only
+#include <bsls_annotation.h>                            // for testing only
 
 #include <bslma_allocator.h>
 #include <bslma_default.h>
@@ -278,6 +279,7 @@ void ScalarPrimitives::doCopyConstruct(TARGET_TYPE         *address,
                                        bslma::Allocator    *allocator,
                                        bsl::false_type)
 {
+    bslma::Allocator *unusedAllocator BSLS_ANNOTATION_UNUSED = allocator;
     new (address) TARGET_TYPE(original);
 }
 
@@ -1449,12 +1451,12 @@ void testLexicographicalBuiltin(bool                    verboseFlag,
                        LINE1, LEN1, LINE2, LEN2);
                 printf("LHS = [ ");
                 for (k = 0; k < LHS_LEN; ++k) {
-                    printf("%s", k ? (char*)", " : (char*)"");
+                    printf("%s", k ? ", " : "");
                     dbg_print(LHS_BEGIN[k]);
                 }
                 printf(" ]\nRHS = [ ");
                 for (k = 0; k < RHS_LEN; ++k) {
-                    printf("%s", k ? (char*)", " : (char*)"");
+                    printf("%s", k ? ", " : "");
                     dbg_print(RHS_BEGIN[k]);
                 }
                 printf(" ]\nEXP = %d, result = %d\n", EXP, result);
@@ -1570,7 +1572,7 @@ static const struct {
 };
 const int NUM_DATA_CASE3 = sizeof DATA_CASE3 / sizeof *DATA_CASE3;
 
-void testGenericEqual(bool verboseFlag, bslma::TestAllocator& testAllocator)
+void testGenericEqual(bool verboseFlag)
     // Compare every pair of strings in the 'DATA_CASE3' array, and verify that
     // they are equal according to the generic 'equal' implementation (using
     // four arguments) if and only if they are equal.
@@ -1844,7 +1846,8 @@ void testGG(bool verbose, bool veryVerbose)
             const int         LENGTH = (int)strlen(SPEC);
 
             TEST_TYPE array[MAX_LENGTH];
-            const TEST_TYPE& X = gg(array, SPEC);   // first element
+            const TEST_TYPE& X BSLS_ANNOTATION_UNUSED = gg(array, SPEC);
+                // first element
 
             if (LENGTH != oldLen) {
                 if (verbose) printf("\tof length %d:\n", LENGTH);
@@ -1930,8 +1933,8 @@ void timeEqualAlgorithm(const char *typeName,
     printf("\n\tcompare with '%s'\n", typeName);
     {
         const int bufferSize = rawBufferSize / sizeof(TYPE);
-        TYPE *buffer1 = (TYPE*)rawBuffer1;
-        TYPE *buffer2 = (TYPE*)rawBuffer2;
+        TYPE *buffer1 = (TYPE*)const_cast<char *>(rawBuffer1);
+        TYPE *buffer2 = (TYPE*)const_cast<char *>(rawBuffer2);
 
         for (int j = 0; j < bufferSize; ++j) {
             buffer1[j] = buffer2[j] = TYPE();
@@ -2004,8 +2007,8 @@ void timeLexicographicalAlgorithm(const char *typeName,
     printf("\n\tcompare with '%s'\n", typeName);
     {
         const int bufferSize = rawBufferSize / sizeof(TYPE);
-        TYPE *buffer1 = (TYPE*)rawBuffer1;
-        TYPE *buffer2 = (TYPE*)rawBuffer2;
+        TYPE *buffer1 = (TYPE*)const_cast<char *>(rawBuffer1);
+        TYPE *buffer2 = (TYPE*)const_cast<char *>(rawBuffer2);
 
         for (int j = 0; j < bufferSize; ++j) {
             buffer1[j] = buffer2[j] = TYPE();
@@ -2277,7 +2280,7 @@ int main(int argc, char *argv[])
         if (veryVerbose) printf("\t... generic 'equal' (four arguments).\n");
 
         if (veryVerbose) printf("\t\tUsing pointer type for iterator.\n");
-        testGenericEqual(veryVerbose, testAllocator);
+        testGenericEqual(veryVerbose);
 
         if (veryVerbose) printf("\t... with 'char'.\n");
         {


### PR DESCRIPTION
Fixes various sets of warnings in this test driver:

```
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1573: warning: unused parameter ‘testAllocator’ [-Wunused-parameter]
```

```
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: In function ‘void testLexicographicalBuiltin(bool, TYPE (*)(int, int), BloombergLP::bslma::TestAllocator&) [with TYPE = int]’:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2189:   instantiated from here
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1452: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1452: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1457: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1457: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
```

```
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: In function ‘void testGG(bool, bool) [with TEST_TYPE = NonBitwiseWithOpEqual]’:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2371:   instantiated from here
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1847: warning: unused variable ‘X’ [-Wunused-variable]
```

```
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: In function ‘void timeEqualAlgorithm(const char*, int, const char*, const char*, int) [with TYPE = char]’:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2523:   instantiated from here
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1933: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:1934: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: In function ‘void timeLexicographicalAlgorithm(const char*, int, const char*, const char*, int) [with TYPE = char]’:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2565:   instantiated from here
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2007: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:2008: warning: cast from type ‘const char*’ to type ‘char*’ casts away constness
```

```
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: At global scope:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp: In instantiation of ‘static void ScalarPrimitives::doCopyConstruct(TARGET_TYPE*, const TARGET_TYPE&, BloombergLP::bslma::Allocator*, bsl::false_type) [with TARGET_TYPE = MyPoint]’:
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:301:   instantiated from ‘static void ScalarPrimitives::copyConstruct(TARGET_TYPE*, const TARGET_TYPE&, BloombergLP::bslma::Allocator*) [with TARGET_TYPE = MyPoint]’
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:518:   instantiated from ‘void MyContainer<VALUE_TYPE>::push_back(const VALUE_TYPE&) [with VALUE_TYPE = MyPoint]’
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:858:   instantiated from here
../groups/bsl/bslalg/bslalg_rangecompare.t.cpp:279: warning: unused parameter ‘allocator’ [-Wunused-parameter]
```
