### PR TITLE
bslalg_rbtreeutil.t: Fix -Wunused warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_rbtreeutil.t.cpp
+++ b/groups/bsl/bslalg/bslalg_rbtreeutil.t.cpp
@@ -5958,14 +5958,13 @@ int main(int argc, char *argv[])
             bsls::AssertFailureHandlerGuard hG(
                                              bsls::AssertTest::failTestDriver);
 
-#ifdef BSLS_ASSERT_IS_ACTIVE
             RbTreeNode node; const RbTreeNode& NODE = node;
+            (void) node;  // Suppress 'unused variable' warnings in non-SAFE modes
             ASSERT_FAIL(Obj::printTreeStructure(0,
                                                 &NODE,
                                                 printIntNodeValue,
                                                 0,
                                                 0));
-#endif
         }
         removeFile(fileName);
 


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bslalg/bslalg_rbtreeutil.t.cpp: In function ‘int main(int, char**)’:
../groups/bsl/bslalg/bslalg_rbtreeutil.t.cpp:5961: warning: unused variable ‘NODE’ [-Wunused-variable]
```

`NODE` is only referenced within a `BSLS_ASSERT`, so place the two statements in a `BSLS_ASSERT_IS_ACTIVE` check.
