### PR TITLE
bslalg_scalardestructionprimitives.t: Fix -Wunused warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_scalardestructionprimitives.t.cpp
+++ b/groups/bsl/bslalg/bslalg_scalardestructionprimitives.t.cpp
@@ -754,13 +754,13 @@ int main(int argc, char *argv[])
             bsls::AssertFailureHandlerGuard g(
                     bsls::AssertTest::failTestDriver);
 
-#ifdef BSLS_ASSERT_SAFE_IS_ACTIVE
             int * null = 0;
+            (void) null;  // Suppress 'unused variable' warnings in non-SAFE modes
             ASSERT_SAFE_FAIL(Obj::destroy(null));
 
             int x = 0;
+            (void) x;     // Suppress 'unused variable' warnings in non-SAFE modes
             ASSERT_SAFE_PASS(Obj::destroy(&x));
-#endif
         }
       } break;
       case 1: {


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bslalg/bslalg_scalardestructionprimitives.t.cpp: In function ‘int main(int, char**)’:
../groups/bsl/bslalg/bslalg_scalardestructionprimitives.t.cpp:757: warning: unused variable ‘null’ [-Wunused-variable]
```

The two variables are only referenced in safe-mode asserts, so add `BSLS_ASSERT_SAFE_IS_ACTIVE` check.
