### PR TITLE
bslalg_typetraithastrivialdefaultconstructor.t: Fix -Wunused warning.

### DIFF
--- a/groups/bsl/bslalg/bslalg_typetraithastrivialdefaultconstructor.t.cpp
+++ b/groups/bsl/bslalg/bslalg_typetraithastrivialdefaultconstructor.t.cpp
@@ -2,8 +2,6 @@
 
 #include <bslalg_typetraithastrivialdefaultconstructor.h>
 
-#include <bsls_annotation.h>  // for testing
-
 #include <cstdio>
 #include <cstdlib>
 
@@ -121,7 +119,8 @@ int main(int argc, char *argv[])
         if (verbose) printf("\nBREATHING TEST"
                             "\n==============");
 
-        Obj mX BSLS_ANNOTATION_UNUSED;
+        Obj mX;
+        (void) mX;  // Suppress 'unused variable' warnings in non-SAFE modes
 
       } break;
 


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bslalg/bslalg_typetraithastrivialdefaultconstructor.t.cpp: In function ‘int main(int, char**)’:
../groups/bsl/bslalg/bslalg_typetraithastrivialdefaultconstructor.t.cpp:122: warning: unused variable ‘mX’ [-Wunused-variable]
```

Adds `BSLS_ANNOTATION_UNUSED` to prevent the warning.
