### PR TITLE
bsls_ident.t: Reference assert implementation.

### DIFF
--- a/groups/bsl/bsls/bsls_ident.t.cpp
+++ b/groups/bsl/bsls/bsls_ident.t.cpp
@@ -156,6 +156,7 @@ int main(int argc, char *argv[])
         if (verbose) std::cout << "\nBREATHING TEST"
                                << "\n==============" << std::endl;
 
+        ASSERT(true);  // Reference assert implementation
 
         std::cout << "\nThere is no real runtime test for this component"
                   << std::endl;


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bsls/bsls_ident.t.cpp:27: warning: ‘void aSsErT(int, const char*, int)’ defined but not used
```
