### PR TITLE
bslstl_bidirectionaliterator.t: Fix unused, signed/unsigned warnings.

### DIFF
--- a/groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp
+++ b/groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp
@@ -634,8 +634,6 @@ int main(int argc, char *argv[])
     int test = argc > 1 ? atoi(argv[1]) : 0;
     int verbose = argc > 2;
     int veryVerbose = argc > 3;
-    int veryVeryVerbose = argc > 4;
-    int veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
 
@@ -1215,8 +1213,8 @@ int main(int argc, char *argv[])
 
         if (verbose) cout << "\nRepeat the tests for const_iterators" << endl;
         const TestContainer& constContainer = testContainer;
-        const_iterator itcBegin = testContainer.begin();
-        const const_iterator itcEnd = testContainer.end();
+        const_iterator itcBegin = constContainer.begin();
+        const const_iterator itcEnd = constContainer.end();
         length = 0;
         while( itcBegin != itcEnd) {
             ++length;
@@ -1224,7 +1222,7 @@ int main(int argc, char *argv[])
         }
         ASSERT(3 == length);
 
-        itcBegin = testContainer.begin();
+        itcBegin = constContainer.begin();
         ASSERT(1 == *itcBegin++);
         ASSERT(2 == *itcBegin++);
         ASSERT(3 == *itcBegin++);
@@ -1284,7 +1282,7 @@ int main(int argc, char *argv[])
 
         const_iterator itReader = testData;
         const int* itValidator = testData;
-        for(int i = 0; i < sizeof(testData)/sizeof(int); ++itValidator,
+        for(size_t i = 0; i < sizeof(testData)/sizeof(int); ++itValidator,
                                                          ++itReader, ++i) {
             LOOP3_ASSERT(i, *itReader, *itValidator,&*itReader == itValidator);
         }


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp: In function ‘int main(int, char**)’:
../groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp:1217: warning: unused variable ‘constContainer’ [-Wunused-variable]
../groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp:1287: warning: comparison between signed and unsigned integer expressions
../groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp:637: warning: unused variable ‘veryVeryVerbose’ [-Wunused-variable]
../groups/bsl/bslstl/bslstl_bidirectionaliterator.t.cpp:638: warning: unused variable ‘veryVeryVeryVerbose’ [-Wunused-variable]
```
