### PR TITLE
bslstl_forwarditerator.t: Fix unused, signed/unsigned warnings.

### DIFF
--- a/groups/bsl/bslstl/bslstl_forwarditerator.t.cpp
+++ b/groups/bsl/bslstl/bslstl_forwarditerator.t.cpp
@@ -132,6 +132,10 @@ void testAssertionFailedHandler(const char *text, const char *file, int line)
     // A handler that sets the global flag 'assertFailed' when an assertion
     // fails.  Due to its simplicity, it isn't tested in test case 3.
 {
+    (void) text;
+    (void) file;
+    (void) line;
+
     assertFailed = true;
 }
 
@@ -369,8 +373,6 @@ int main(int argc, char *argv[])
     int test = argc > 1 ? atoi(argv[1]) : 0;
     int verbose = argc > 2;
     int veryVerbose = argc > 3;
-    int veryVeryVerbose = argc > 4;
-    int veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
 
@@ -845,8 +847,8 @@ int main(int argc, char *argv[])
 
         if (verbose) cout << "\nRepeat the tests for const_iterators" << endl;
         const TestContainer& constContainer = testContainer;
-        const_iterator itcBegin = testContainer.begin();
-        const const_iterator itcEnd = testContainer.end();
+        const_iterator itcBegin = constContainer.begin();
+        const const_iterator itcEnd = constContainer.end();
         length = 0;
         while( itcBegin != itcEnd) {
             ++length;
@@ -854,7 +856,7 @@ int main(int argc, char *argv[])
         }
         ASSERT(3 == length);
 
-        itcBegin = testContainer.begin();
+        itcBegin = constContainer.begin();
         ASSERT(1 == *itcBegin++);
         ASSERT(2 == *itcBegin++);
         ASSERT(3 == *itcBegin++);
@@ -913,7 +915,7 @@ int main(int argc, char *argv[])
 
         const_iterator itReader = testData;
         const int* itValidator = testData;
-        for(int i = 0; i < sizeof(testData)/sizeof(int); ++itValidator,
+        for(size_t i = 0; i < sizeof(testData)/sizeof(int); ++itValidator,
                                                          ++itReader, ++i) {
             LOOP2_ASSERT(*itValidator, *itReader, *itValidator == *itReader);
         }


### PR DESCRIPTION
Fixes:

```
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:131: warning: unused parameter ‘text’ [-Wunused-parameter]
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:131: warning: unused parameter ‘file’ [-Wunused-parameter]
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:131: warning: unused parameter ‘line’ [-Wunused-parameter]
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp: In function ‘int main(int, char**)’:
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:847: warning: unused variable ‘constContainer’ [-Wunused-variable]
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:916: warning: comparison between signed and unsigned integer expressions
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:372: warning: unused variable ‘veryVeryVerbose’ [-Wunused-variable]
../groups/bsl/bslstl/bslstl_forwarditerator.t.cpp:373: warning: unused variable ‘veryVeryVeryVerbose’ [-Wunused-variable]
```
