### PR TITLE
Eliminate reliance on special CLANG_GNUC_* macros.

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -197,9 +197,6 @@
           [ 'OS == "mac"', {
             'defines_base': [
               '__unix',              # xcodebuild/clang does not define __unix
-              '__CLANG_GNUC__=4',
-              '__CLANG_GNUC_MINOR__=2',
-              '__CLANG_GNUC_PATCHLEVEL__=1',
             ],
             'cflags_abi_32=': [ 'i386' ],
             'cflags_abi_64=': [ 'x86_64' ],

--- a/groups/bsl/bsls/bsls_platform.h
+++ b/groups/bsl/bsls/bsls_platform.h
@@ -471,14 +471,9 @@ struct bsls_Platform_Assert;
         #if defined(__clang__)
             // Clang is GCC compatible, but sometimes we need to know about it
             #define BSLS_PLATFORM_CMP_CLANG 1
-
-            #if defined(__CLANG_GNUC_PATCHLEVEL__)
-                #define BSLS_PLATFORM_CMP_VERSION (__CLANG_GNUC__ * 10000 \
-                      + __CLANG_GNUC_MINOR__ * 100 + __CLANG_GNUC_PATCHLEVEL__)
-            #else
-                #define BSLS_PLATFORM_CMP_VERSION (__CLANG_GNUC__ * 10000 \
-                            + __CLANG_GNUC_MINOR__ * 100)
-            #endif
+            // We treat Clang as if it was GCC 4.4.0
+            #define BSLS_PLATFORM_CMP_VERSION (4 * 10000 \
+                            + 4 * 100)
         #else
             #if defined(__GNUC_PATCHLEVEL__)
                 #define BSLS_PLATFORM_CMP_VERSION (__GNUC__ * 10000 \


### PR DESCRIPTION
The BSL platform header relied on custom preprocessor macros that had
to be provided by the build system when Clang was used to compile. In fact
these macros don't appear to be necessary, and the same effect can be
achieved by using the GNUC_\* macros that Clang already defines as part
of its emulation of GCC.

This has been tested on OSX with Xcode 4.5, and on openSUSE 12.2 using both Clang 3.1 and GCC 4.7, and on the Linux matrix build of seven platforms.
