### PR TITLE
Add support for running test drivers inside Valgrind.

### DIFF
--- a/tools/run_unit_tests.py
+++ b/tools/run_unit_tests.py
@@ -23,6 +23,7 @@ def parseOptions():
     parser.add_option("--abi", dest="abi")
     parser.add_option("--lib", dest="lib")
     parser.add_option("--junit", dest="junit")
+    parser.add_option("--valgrind", dest="valgrind")
     (options, args) = parser.parse_args()
 
     return options
@@ -381,7 +382,7 @@ class TestRunner:
         return TestRunner.testOver.match(line)
 
     @staticmethod
-    def runTest(test, verbosityLevel, timeout):
+    def runTest(test, verbosityLevel, timeout, valgrind):
         failures = 0
         testNumber = 1
 
@@ -394,7 +395,14 @@ class TestRunner:
                 
             policy = PolicyFilter.getTestPolicy(test, testNumber)
                 
-            args = [program, str(testNumber)]
+            args = []
+
+            if (valgrind):
+                valgrindFile = valgrind % (testNumber)
+                args.extend(['valgrind','--quiet','--tool=memcheck','--leak-check=yes','--xml=yes',"--xml-file=%s" % valgrindFile])
+
+            args.extend([program, str(testNumber)])
+
             out.startTestCase(testNumber)
             if verbosityLevel >= 0:
                 args.extend(['v' for n in range(verbosityLevel)])
@@ -484,7 +492,7 @@ if 'TIMEOUT' in os.environ:
 
 out.startTestSuite(sys.argv[1], verbosityLevel, timeout)
 
-returncode = TestRunner.runTest(sys.argv[1], verbosityLevel, timeout)
+returncode = TestRunner.runTest(sys.argv[1], verbosityLevel, timeout, commandLineOptions.valgrind)
 
 returncode = out.endTestSuite(returncode)
 


### PR DESCRIPTION
This patch adds a '--valgrind' command line option to run_unit_tests.py. The option
accepts an argument which is a filename _pattern_. When this option is supplied,
each test case will be executed inside a Valgrind wrapper with the leak-check tool
enabled, and Valgrind's output will be directed (in XML format) to a file specified
by that pattern. The pattern will undergo string substitution with a single parameter,
which will be the test case number that is being executed (so the pattern should use
a "%d"-style format string to format it).
