### PR TITLE
Add support for 'ldflags_extra' in build system.

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -88,6 +88,7 @@
             'ldflags_abi_32%': [ '-m32' ],
             'ldflags_abi_64%': [ '-m64' ],
             'ldflags_PIC%': [ '-fPIC' ],
+            'ldflags_extra%': [ ],
           }], # linker_tag == "gnu_ld"
 
 
@@ -121,6 +122,7 @@
             'ldflags_abi_32%': [ '-q32 -b32 -brtl' ],
             'ldflags_abi_64%': [ '-q64 -b64 -brtl' ],
             'ldflags_PIC%': [ ],
+            'ldflags_extra%': [ ],
           }], # linker_tag == "aix_ld"
 
 
@@ -145,6 +147,7 @@
             'ldflags_abi_32%': [ '-m32' ],
             'ldflags_abi_64%': [ '-m64' ],
             'ldflags_PIC%': [ ],
+            'ldflags_extra%': [ ],
           }], # linker_tag == "solaris_ld"
 
 
@@ -182,6 +185,7 @@
             'ldflags_abi_32%': [ ],
             'ldflags_abi_64%': [ ],
             'ldflags_PIC%': [ ],
+            'ldflags_extra%': [ ],
           }], # linker_tag == "msvs"
 
 
@@ -211,7 +215,6 @@
       'linker_tag%': '<(linker_tag)',
       'defines_base': [ '<@(defines_base)' ],
       'cflags_base%':  [ '<@(cflags_base)' ],
-      'ldflags_base%': [ '<@(ldflags_base)' ],
       'cflags_opt%':   [ '<@(cflags_opt)' ],
       'cflags_c_debug%': [ '<@(cflags_c_debug)' ],
       'cflags_cc_debug%': [ '<@(cflags_cc_debug)' ],
@@ -221,10 +224,12 @@
       'cflags_diags%': [ '<@(cflags_diags)' ],
       'cflags_abi_32%': [ '<@(cflags_abi_32)' ],
       'cflags_abi_64%': [ '<@(cflags_abi_64)' ],
+      'cflags_PIC%':  [ '<@(cflags_PIC)' ],
+      'ldflags_base%': [ '<@(ldflags_base)' ],
       'ldflags_abi_32%': [ '<@(ldflags_abi_32)' ],
       'ldflags_abi_64%': [ '<@(ldflags_abi_64)' ],
-      'cflags_PIC%':  [ '<@(cflags_PIC)' ],
       'ldflags_PIC%': [ '<@(ldflags_PIC)' ],
+      'ldflags_extra%': [ '<@(ldflags_extra)' ],
 
       'conditions': [
         [ 'ABI_bits == 64', {
@@ -245,7 +250,6 @@
      'linker_tag%': '<(linker_tag)',
      'defines_base': [ '<@(defines_base)' ],
      'cflags_base%':  [ '<@(cflags_base)' ],
-     'ldflags_base%': [ '<@(ldflags_base)' ],
      'cflags_opt%':   [ '<@(cflags_opt)' ],
      'cflags_c_debug%': [ '<@(cflags_c_debug)' ],
      'cflags_cc_debug%': [ '<@(cflags_cc_debug)' ],
@@ -254,9 +258,11 @@
      'cflags_cc_extra%': [ '<@(cflags_cc_extra)' ],
      'cflags_diags%': [ '<@(cflags_diags)' ],
      'cflags_abi%':  [ '<@(cflags_abi)' ],
-     'ldflags_abi%': [ '<@(ldflags_abi)' ],
      'cflags_PIC%':  [ '<@(cflags_PIC)' ],
+     'ldflags_base%': [ '<@(ldflags_base)' ],
+     'ldflags_abi%': [ '<@(ldflags_abi)' ],
      'ldflags_PIC%': [ '<@(ldflags_PIC)' ],
+     'ldflags_extra%': [ '<@(ldflags_extra)' ],
 
     }, # variables
 
@@ -280,7 +286,8 @@
                          'cflags_cc': [ '<@(cflags_cc_exc)',
                                         '<@(cflags_cc_extra)', ],
                          'ldflags':   [ '<@(ldflags_abi)',
-                                        '<@(ldflags_base)' ],
+                                        '<@(ldflags_base)',
+                                        '<@(ldflags_extra)', ],
                          'msvs_settings': {
                            'VCCLCompilerTool': {
                              'Optimization': '2',
@@ -298,7 +305,8 @@
                                         '<@(cflags_cc_debug)',
                                         '<@(cflags_cc_extra)', ],
                          'ldflags':   [ '<@(ldflags_abi)',
-                                        '<@(ldflags_base)' ],
+                                        '<@(ldflags_base)',
+                                        '<@(ldflags_extra)', ],
                          'msvs_settings': {
                            'VCCLCompilerTool': {
                              'Optimization': '0',


### PR DESCRIPTION
This patch adds the ability to specify extra (additional) flags to the
linker when bsl_gyp.py is executed (by adding a command line option
similar to `-D ldflags_extra=<flags>`). This parallels the existing
 `cflags_extra` support.
