### PR TITLE
bsls_ident.t.cpp: included cstdio, removed iostream, replace cout with printf

### DIFF
--- a/groups/bsl/bsls/bsls_ident.t.cpp
+++ b/groups/bsl/bsls/bsls_ident.t.cpp
@@ -5,10 +5,13 @@
 // *** The format of this component test driver is non-standard. ***
 
 // #include <bsls_ident.h>      // included below in usage example.
-#include <cstdlib>              // 'atoi'
-#include <iostream>
+#include <bsls_bsltestutil.h>
 
-// using namespace BloombergLP;
+#include <cstdlib>              // 'atoi'
+#include <cstdio>
+
+using namespace BloombergLP;
+using namespace bsls;
 
 //=============================================================================
 //                             TEST PLAN
@@ -26,52 +29,32 @@ static int testStatus = 0;
 
 static void aSsErT(int c, const char *s, int i) {
     if (c) {
-        std::cout << "Error " << __FILE__ << "(" << i << "): " << s
-                  << "    (failed)" << std::endl;
+        printf("Error " __FILE__ "(%d): %s    (failed)\n", i, s);
         if (testStatus >= 0 && testStatus <= 100) ++testStatus;
     }
 }
 
-# define ASSERT(X) { aSsErT(!(X), #X, __LINE__); }
 //--------------------------------------------------------------------------
-#define LOOP_ASSERT(I,X) { \
-    if (!(X)) { std::cout << #I << ": " << I << "\n"; \
-                aSsErT(1, #X, __LINE__); } }
-
-#define LOOP2_ASSERT(I,J,X) { \
-    if (!(X)) { std::cout << #I << ": " << I << "\t" << #J << ": " \
-                          << J << "\n"; aSsErT(1, #X, __LINE__); } }
-
-#define LOOP3_ASSERT(I,J,K,X) { \
-   if (!(X)) { std::cout << #I << ": " << I << "\t" << #J << ": " << J \
-                         << "\t" << #K << ": " << K << "\n";           \
-                aSsErT(1, #X, __LINE__); } }
-
-#define LOOP4_ASSERT(I,J,K,L,X) { \
-   if (!(X)) { std::cout << #I << ": " << I << "\t" << #J << ": " << J \
-                         << "\t" << #K << ": " << K << "\t" << #L << ": " \
-                         << L << "\n"; aSsErT(1, #X, __LINE__); } }
-
-#define LOOP5_ASSERT(I,J,K,L,M,X) { \
-   if (!(X)) { std::cout << #I << ": " << I << "\t" << #J << ": " << J    \
-                         << "\t" << #K << ": " << K << "\t" << #L << ": " \
-                         << L << "\t" << #M << ": " << M << "\n";         \
-               aSsErT(1, #X, __LINE__); } }
-
-#define LOOP6_ASSERT(I,J,K,L,M,N,X) { \
-   if (!(X)) { std::cout << #I << ": " << I << "\t" << #J << ": " << J     \
-                         << "\t" << #K << ": " << K << "\t" << #L << ": "  \
-                         << L << "\t" << #M << ": " << M << "\t" << #N     \
-                         << ": " << N << "\n"; aSsErT(1, #X, __LINE__); } }
-
 //=============================================================================
-//                  SEMI-STANDARD TEST OUTPUT MACROS
+//                       STANDARD BDE TEST DRIVER MACROS
 //-----------------------------------------------------------------------------
-#define P(X) std::cout << #X " = " << (X) << std::endl; // Print ID and value.
-#define Q(X) std::cout << "<| " #X " |>" << std::endl;  // Quote ID literally.
-#define P_(X) std::cout << #X " = " << (X) << ", " << flush; // P(X) w/o '\n'
-#define L_ __LINE__                                // current Line number
-#define T_ std::cout << "\t" << flush;             // Print a tab (w/o newline)
+
+#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
+#define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
+#define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
+#define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT
+#define LOOP2_ASSERT BSLS_BSLTESTUTIL_LOOP2_ASSERT
+#define LOOP3_ASSERT BSLS_BSLTESTUTIL_LOOP3_ASSERT
+#define LOOP4_ASSERT BSLS_BSLTESTUTIL_LOOP4_ASSERT
+#define LOOP5_ASSERT BSLS_BSLTESTUTIL_LOOP5_ASSERT
+#define LOOP6_ASSERT BSLS_BSLTESTUTIL_LOOP6_ASSERT
+#define ASSERTV      BSLS_BSLTESTUTIL_ASSERTV
+
+#define Q   BSLS_BSLTESTUTIL_Q   // Quote identifier literally.
+#define P   BSLS_BSLTESTUTIL_P   // Print identifier and value.
+#define P_  BSLS_BSLTESTUTIL_P_  // P(X) without '\n'.
+#define T_  BSLS_BSLTESTUTIL_T_  // Print a tab (w/o newline).
+#define L_  BSLS_BSLTESTUTIL_L_  // current Line number
 
 //=============================================================================
 //                  GLOBAL TYPEDEFS/CONSTANTS FOR TESTING
@@ -140,7 +123,7 @@ int main(int argc, char *argv[])
 //    int veryVerbose = argc > 3;
 //    int veryVeryVerbose = argc > 4;
 
-    std::cout << "TEST " << __FILE__ << " CASE " << test << std::endl;;
+    printf("TEST " __FILE__ " CASE %d\n", test);
 
     switch (test) { case 0:  // Zero is always the leading case.
       case 1: {
@@ -153,24 +136,24 @@ int main(int argc, char *argv[])
         //   Do nothing.
         // --------------------------------------------------------------------
 
-        if (verbose) std::cout << "\nBREATHING TEST"
-                               << "\n==============" << std::endl;
+        if (verbose) printf("\nBREATHING TEST"
+                            "\n==============\n");
 
         ASSERT(true);  // Reference assert implementation
 
-        std::cout << "\nThere is no real runtime test for this component"
-                  << std::endl;
+        if (verbose)
+            printf("\nThere is no real runtime test for this component\n");
+
 
       } break;
       default: {
-        std::cerr << "WARNING: CASE `" << test << "' NOT FOUND." << std::endl;
+        fprintf(stderr, "WARNING: CASE `%d' NOT FOUND.\n", test);
         testStatus = -1;
       }
     }
 
     if (testStatus > 0) {
-        std::cerr << "Error, non-zero test status = " << testStatus << "."
-                  << std::endl;
+        fprintf(stderr, "Error, non-zero test status = %d.\n", testStatus);
     }
 
     return testStatus;


### PR DESCRIPTION
The bsl package group is a low level package group which needs to be tested with minimal test dependencies which defines its "level."   Examined 11 sample files for usage of cout and found only one file with multiple instances of cout.  In that file, we replaced multiple cout uses with the corresponding printf/fprintf/putchar function calls.
- included <cstdio>
- removed <iostream>
- replaced cout with printf in aSsErT macro
- replace cout with printf in LOOP_ASSERT macro
- replace cout with printf in LOOP2_ASSERT macro
- replace cout with printf in LOOP3_ASSERT macro
- replace cout with printf in LOOP4_ASSERT macro
- replace cout with printf in LOOP5_ASSERT macro
- replace cout with printf in LOOP6_ASSERT macro
- replace cout with printf in Q() macro
- replace cout with printf in P() macro
- replace cout with printf in P_() macro
- replace cout with printf in L_ macro
- replace cout with putchar in T_ macro
- replace cout with printf for main TEST CASE Banner
- replace cout with printf in Test Case Banners
- replace cout with printf in if (verbose)
- replace cerr with fprintf in default Case
- replace cerr with fprintf in testStatus check
