### PR TITLE
README.md: fix issue tracker link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ BSL is distributed under a simple MIT-style license; see the LICENSE file at the
 Question, Comments and Feedback
 ===============================
 If you have questions, comments, suggestions for improvement or any other inquiries regarding BSL, feel free to open an issue
-in the [issue tracker](bsl/issues).
+in the [issue tracker](https://github.com/bloomberg/bsl/issues).


### PR DESCRIPTION
Currently, the link is broken, it points to https://github.com/bloomberg/bsl/blob/master/bsl/issues which gives a 404. Perhaps github changed their URL layout. Fix this.
