### PR TITLE
more consistent use of BSLS_UTIL_ADDRESSOF() macro

### DIFF
--- a/groups/bsl/bslma/bslma_sharedptroutofplacerep.h
+++ b/groups/bsl/bslma/bslma_sharedptroutofplacerep.h
@@ -711,7 +711,7 @@ void *
 SharedPtrOutofplaceRep<TYPE, DELETER>::getDeleter(const std::type_info& type)
 {
     return (typeid(d_deleter) == type)
-         ? bsls::Util::addressOf(d_deleter)
+         ? BSLS_UTIL_ADDRESSOF(d_deleter)
          : 0;
 }
 #endif

--- a/groups/bsl/bslstl/bslstl_bidirectionalnodepool.h
+++ b/groups/bsl/bslstl/bslstl_bidirectionalnodepool.h
@@ -402,7 +402,7 @@ BidirectionalNodePool<VALUE, ALLOCATOR>::createNode()
     bslma::DeallocatorProctor<Pool> proctor(node, &d_pool);
 
     AllocatorTraits::construct(allocator(),
-                               bsls::Util::addressOf(node->value()));
+                               BSLS_UTIL_ADDRESSOF(node->value()));
 
     proctor.release();
     return node;
@@ -418,7 +418,7 @@ BidirectionalNodePool<VALUE, ALLOCATOR>::createNode(const SOURCE& value)
     bslma::DeallocatorProctor<Pool> proctor(node, &d_pool);
 
     AllocatorTraits::construct(allocator(),
-                               bsls::Util::addressOf(node->value()),
+                               BSLS_UTIL_ADDRESSOF(node->value()),
                                value);
     proctor.release();
     return node;
@@ -435,7 +435,7 @@ BidirectionalNodePool<VALUE, ALLOCATOR>::createNode(const FIRST_ARG&  first,
     bslma::DeallocatorProctor<Pool> proctor(node, &d_pool);
 
     AllocatorTraits::construct(allocator(),
-                               bsls::Util::addressOf(node->value()),
+                               BSLS_UTIL_ADDRESSOF(node->value()),
                                first,
                                second);
     proctor.release();
@@ -462,7 +462,7 @@ void BidirectionalNodePool<VALUE, ALLOCATOR>::deleteNode(
     bslalg::BidirectionalNode<VALUE> *node =
                      static_cast<bslalg::BidirectionalNode<VALUE> *>(linkNode);
     AllocatorTraits::destroy(allocator(),
-                             bsls::Util::addressOf(node->value()));
+                             BSLS_UTIL_ADDRESSOF(node->value()));
     d_pool.deallocate(node);
 }
 

--- a/groups/bsl/bslstl/bslstl_hashtablebucketiterator.h
+++ b/groups/bsl/bslstl/bslstl_hashtablebucketiterator.h
@@ -431,7 +431,7 @@ operator->() const
 {
     BSLS_ASSERT_SAFE(this->d_node_p);
 
-    return bsls::Util::addressOf(
+    return BSLS_UTIL_ADDRESSOF(
             static_cast<bslalg::BidirectionalNode<VALUE_TYPE> *>(
                                                            d_node_p)->value());
 }

--- a/groups/bsl/bslstl/bslstl_hashtablebucketiterator.t.cpp
+++ b/groups/bsl/bslstl/bslstl_hashtablebucketiterator.t.cpp
@@ -1099,7 +1099,7 @@ void TestDriver<VALUE>::testCase4()
             ASSERT(BUCKET == X.bucket());
             ASSERT(NODE == X.node());
             ASSERT(NODE->value() == *X);
-            ASSERT(bsls::Util::addressOf(NODE->value()) == X.operator->());
+            ASSERT(BSLS_UTIL_ADDRESSOF(NODE->value()) == X.operator->());
         }
     }
 }

--- a/groups/bsl/bslstl/bslstl_hashtableiterator.h
+++ b/groups/bsl/bslstl/bslstl_hashtableiterator.h
@@ -385,7 +385,7 @@ HashTableIterator<VALUE_TYPE, DIFFERENCE_TYPE>::operator->() const
 {
     BSLS_ASSERT_SAFE(this->d_node_p);
 
-    return bsls::Util::addressOf(
+    return BSLS_UTIL_ADDRESSOF(
             static_cast<bslalg::BidirectionalNode<VALUE_TYPE> *>(
                                                            d_node_p)->value());
 }

--- a/groups/bsl/bslstl/bslstl_hashtableiterator.t.cpp
+++ b/groups/bsl/bslstl/bslstl_hashtableiterator.t.cpp
@@ -980,7 +980,7 @@ void TestDriver<VALUE>::testCase4()
         const Obj& X = mX;
         ASSERTV(ti, X.node() == nodes[ti]);
         ASSERTV(ti, *X == nodes[ti]->value());
-        ASSERTV(ti, X.operator->() == bsls::Util::addressOf(nodes[ti]->value()));
+        ASSERTV(ti, X.operator->() == BSLS_UTIL_ADDRESSOF(nodes[ti]->value()));
     }
 
     // Clean up the nodes.

--- a/groups/bsl/bslstl/bslstl_list.h
+++ b/groups/bsl/bslstl/bslstl_list.h
@@ -1692,10 +1692,8 @@ void bsl::List_Node<VALUE>::init()
     // will be responsible for constructing 'd_prev' and 'd_next', rather
     // than just setting them to null:
     //
-    //    new ((void*) BloombergLP::bsls::Util::addressOf(d_prev))
-    //                                                        NodePtr(nullptr);
-    //    new ((void*) BloombergLP::bsls::Util::addressOf(d_next))
-    //                                                        NodePtr(nullptr);
+    //    new ((void*) BSLS_UTIL_ADDRESSOF(d_prev)) NodePtr(nullptr);
+    //    new ((void*) BSLS_UTIL_ADDRESSOF(d_next)) NodePtr(nullptr);
 
     d_prev = d_next = 0;
 }
@@ -1751,7 +1749,7 @@ inline
 typename bsl::List_Iterator<VALUE, NODEPTR, DIFFTYPE>::pointer
 bsl::List_Iterator<VALUE, NODEPTR, DIFFTYPE>::operator->() const
 {
-    return BloombergLP::bsls::Util::addressOf(this->d_nodeptr->d_value);
+    return BSLS_UTIL_ADDRESSOF(this->d_nodeptr->d_value);
 }
 
 template <class VALUE, class NODEPTR, class DIFFTYPE>
@@ -2580,7 +2578,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position, ARGS&&... args)
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            std::forward<ARGS>(args)...);
     proctor.release();
     return insert_node(position, p);
@@ -2596,7 +2594,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position)
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value));
+                           BSLS_UTIL_ADDRESSOF(p->d_value));
     proctor.release();
     return insert_node(position, p);
 }
@@ -2610,7 +2608,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
     proctor.release();
     return insert_node(position, p);
@@ -2627,7 +2625,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
     proctor.release();
@@ -2647,7 +2645,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
@@ -2670,7 +2668,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
@@ -2696,7 +2694,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
@@ -2716,7 +2714,7 @@ list<VALUE, ALLOCATOR>::emplace(const_iterator position,
     NodePtr p = allocate_node();
     NodeProctor proctor(this, p);
     AllocTraits::construct(allocator(),
-                           BloombergLP::bsls::Util::addressOf(p->d_value),
+                           BSLS_UTIL_ADDRESSOF(p->d_value),
                            BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
     proctor.release();
     return insert_node(position, p);
@@ -2771,7 +2769,7 @@ list<VALUE, ALLOCATOR>::erase(const_iterator position)
 
     link_nodes(p->d_prev, p->d_next);
     AllocTraits::destroy(allocator(),
-                         BloombergLP::bsls::Util::addressOf(p->d_value));
+                         BSLS_UTIL_ADDRESSOF(p->d_value));
     free_node(p);
     --size_ref();
     return ret;

--- a/groups/bsl/bslstl/bslstl_map.t.cpp
+++ b/groups/bsl/bslstl/bslstl_map.t.cpp
@@ -797,13 +797,13 @@ struct CharToPairConverter {
         
         bsls::ObjectBuffer<KEY> tempKey;
         bsltf::TemplateTestFacility::emplace(
-                                       bsls::Util::addressOf(tempKey.object()),
+                                       BSLS_UTIL_ADDRESSOF(tempKey.object()),
                                        value,
                                        privateAllocator);
 
         bsls::ObjectBuffer<VALUE> tempValue;
         bsltf::TemplateTestFacility::emplace(
-                                     bsls::Util::addressOf(tempValue.object()),
+                                     BSLS_UTIL_ADDRESSOF(tempValue.object()),
                                      value - 'A' + '0',
                                      privateAllocator);
 

--- a/groups/bsl/bslstl/bslstl_multimap.t.cpp
+++ b/groups/bsl/bslstl/bslstl_multimap.t.cpp
@@ -793,13 +793,13 @@ struct CharToPairConverter {
         
         bsls::ObjectBuffer<KEY> tempKey;
         bsltf::TemplateTestFacility::emplace(
-                                       bsls::Util::addressOf(tempKey.object()),
+                                       BSLS_UTIL_ADDRESSOF(tempKey.object()),
                                        value,
                                        privateAllocator);
 
         bsls::ObjectBuffer<VALUE> tempValue;
         bsltf::TemplateTestFacility::emplace(
-                                     bsls::Util::addressOf(tempValue.object()),
+                                     BSLS_UTIL_ADDRESSOF(tempValue.object()),
                                      value - 'A' + '0',
                                      privateAllocator);
 

--- a/groups/bsl/bslstl/bslstl_setcomparator.t.cpp
+++ b/groups/bsl/bslstl/bslstl_setcomparator.t.cpp
@@ -509,7 +509,7 @@ void TestDriver<TYPE>::test3()
         Node *n1Ptr = AllocTraits::allocate(allocator, 1);
 
         Node& mN1 = *n1Ptr; const Node& N1 = mN1;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
 
         mN1.value() = bsltf::TemplateTestFacility::create<Key>(1);
 
@@ -527,7 +527,7 @@ void TestDriver<TYPE>::test3()
         ASSERTV(ncComp.keyComparator().numCalls(),
                 2 == ncComp.keyComparator().numCalls());
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
         AllocTraits::deallocate(allocator, n1Ptr, 1);
     }
 
@@ -543,7 +543,7 @@ void TestDriver<TYPE>::test3()
         Node *n1Ptr = AllocTraits::allocate(allocator, 1);
 
         Node& mN1 = *n1Ptr; const Node& N1 = mN1;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
 
         mN1.value() = bsltf::TemplateTestFacility::create<Key>(1);
 
@@ -578,7 +578,7 @@ void TestDriver<TYPE>::test3()
                 2 == ncComp.keyComparator().numCalls());
         ASSERTV(0 == ncFunctor.numCalls());
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
         AllocTraits::deallocate(allocator, n1Ptr, 1);
     }
 
@@ -600,7 +600,7 @@ void TestDriver<TYPE>::test3()
         Node *n1Ptr = AllocTraits::allocate(allocator, 1);
 
         Node& mN1 = *n1Ptr; const Node& N1 = mN1;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
 
         mN1.value() = bsltf::TemplateTestFacility::create<Key>(1);
 
@@ -611,7 +611,7 @@ void TestDriver<TYPE>::test3()
         ASSERTV(comp.keyComparator().numCalls(),
                 2 == comp.keyComparator().numCalls());
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
         AllocTraits::deallocate(allocator, n1Ptr, 1);
     }
 
@@ -633,7 +633,7 @@ void TestDriver<TYPE>::test3()
         Node *n1Ptr = AllocTraits::allocate(allocator, 1);
 
         Node& mN1 = *n1Ptr; const Node& N1 = mN1;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
 
         mN1.value() = bsltf::TemplateTestFacility::create<Key>(1);
 
@@ -643,7 +643,7 @@ void TestDriver<TYPE>::test3()
         ASSERTV(K0, N1.value(), !comp(N1, K0));
         ASSERTV(numFunctionComp, 2 == numFunctionComp);
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN1.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN1.value()));
         AllocTraits::deallocate(allocator, n1Ptr, 1);
     }
 }
@@ -771,12 +771,12 @@ void TestDriver<TYPE>::test1()
 
         Node *nPtr = AllocTraits::allocate(allocator, 1);
         Node& mN = *nPtr; const Node& N = mN;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN.value()));
 
         mN.value() = K0;
         ASSERTV(N.value(), K0, comp(N, K1));
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN.value()));
 
         AllocTraits::deallocate(allocator, nPtr, 1);
     }
@@ -795,12 +795,12 @@ void TestDriver<TYPE>::test1()
 
         Node *nPtr = AllocTraits::allocate(allocator, 1);
         Node& mN = *nPtr; const Node& N = mN;
-        AllocTraits::construct(allocator, bsls::Util::addressOf(mN.value()));
+        AllocTraits::construct(allocator, BSLS_UTIL_ADDRESSOF(mN.value()));
 
         mN.value() = K0;
         ASSERTV(N.value(), K0, comp(N, K1));
 
-        AllocTraits::destroy(allocator, bsls::Util::addressOf(mN.value()));
+        AllocTraits::destroy(allocator, BSLS_UTIL_ADDRESSOF(mN.value()));
 
         AllocTraits::deallocate(allocator, nPtr, 1);
     }

--- a/groups/bsl/bslstl/bslstl_treeiterator.h
+++ b/groups/bsl/bslstl/bslstl_treeiterator.h
@@ -383,7 +383,7 @@ TreeIterator<VALUE, NODE, DIFFERENCE_TYPE>::operator->() const
 {
     BSLS_ASSERT_SAFE(d_node_p);
 
-    return bsls::Util::addressOf(static_cast<NODE *>(d_node_p)->value());
+    return BSLS_UTIL_ADDRESSOF(static_cast<NODE *>(d_node_p)->value());
 }
 
 template <class VALUE, class NODE, class DIFFERENCE_TYPE>

--- a/groups/bsl/bslstl/bslstl_treenode.h
+++ b/groups/bsl/bslstl/bslstl_treenode.h
@@ -122,7 +122,7 @@ BSLS_IDENT("$Id: $")
 //  {
 //      TreeNode<VALUE> *result = AllocatorTraits::allocate(d_allocator, 1);
 //      AllocatorTraits::construct(d_allocator,
-//                                 bsls::Util::addressOf(result->value()),
+//                                 BSLS_UTIL_ADDRESSOF(result->value()),
 //                                 value);
 //      return result;
 //  }
@@ -139,7 +139,7 @@ BSLS_IDENT("$Id: $")
 //  {
 //      TreeNode<VALUE> *treeNode = static_cast<TreeNode<VALUE> *>(node);
 //      AllocatorTraits::destroy(d_allocator,
-//                               bsls::Util::addressOf(treeNode->value()));
+//                               BSLS_UTIL_ADDRESSOF(treeNode->value()));
 //      AllocatorTraits::deallocate(d_allocator, treeNode, 1);
 //  }
 //..

--- a/groups/bsl/bslstl/bslstl_treenode.t.cpp
+++ b/groups/bsl/bslstl/bslstl_treenode.t.cpp
@@ -206,7 +206,7 @@ bool TestType1::s_constructedFlag = false;
     {
         TreeNode<VALUE> *result = AllocatorTraits::allocate(d_allocator, 1);
         AllocatorTraits::construct(d_allocator,
-                                   bsls::Util::addressOf(result->value()),
+                                   BSLS_UTIL_ADDRESSOF(result->value()),
                                    value);
         return result;
     }
@@ -223,7 +223,7 @@ bool TestType1::s_constructedFlag = false;
     {
         TreeNode<VALUE> *treeNode = static_cast<TreeNode<VALUE> *>(node);
         AllocatorTraits::destroy(d_allocator,
-                                 bsls::Util::addressOf(treeNode->value()));
+                                 BSLS_UTIL_ADDRESSOF(treeNode->value()));
         AllocatorTraits::deallocate(d_allocator, treeNode, 1);
     }
 //..
@@ -498,7 +498,7 @@ int main(int argc, char *argv[])
             (void) X;
 
             AllocTraits::construct(allocator,
-                                   bsls::Util::addressOf(mX.value()));
+                                   BSLS_UTIL_ADDRESSOF(mX.value()));
             ASSERTV(Type::isConstructed());
             ASSERTV(0 == da.numBlocksInUse());
             ASSERTV(1 == oa.numBlocksInUse());
@@ -578,7 +578,7 @@ int main(int argc, char *argv[])
             Obj& mX = *xPtr; const Obj& X = mX;
 
             AllocTraits::construct(allocator,
-                                   bsls::Util::addressOf(mX.value()));
+                                   BSLS_UTIL_ADDRESSOF(mX.value()));
 
             const char D[] = "";
             const char A[] = "a_" SUFFICIENTLY_LONG_STRING;

--- a/groups/bsl/bslstl/bslstl_unorderedmap.t.cpp
+++ b/groups/bsl/bslstl/bslstl_unorderedmap.t.cpp
@@ -5781,13 +5781,13 @@ struct CharToPairConverter {
         
         bsls::ObjectBuffer<KEY> tempKey;
         bsltf::TemplateTestFacility::emplace(
-                                       bsls::Util::addressOf(tempKey.object()),
+                                       BSLS_UTIL_ADDRESSOF(tempKey.object()),
                                        value,
                                        privateAllocator);
 
         bsls::ObjectBuffer<VALUE> tempValue;
         bsltf::TemplateTestFacility::emplace(
-                                     bsls::Util::addressOf(tempValue.object()),
+                                     BSLS_UTIL_ADDRESSOF(tempValue.object()),
                                      value - 'A' + '0',
                                      privateAllocator);
 
@@ -8887,7 +8887,7 @@ void TestDriver<KEY, VALUE, HASH, EQUAL, ALLOC>::testCase2()
                 int numPasses = 0;
                 EXCEPTION_TEST_BEGIN(mX) {
                     ++numPasses;
-                    pv = bsls::Util::addressOf(mX[VALUES[tj].first]);
+                    pv = BSLS_UTIL_ADDRESSOF(mX[VALUES[tj].first]);
                 } EXCEPTION_TEST_END
                 ASSERTV(1 == numPasses);
                 ASSERTV(LENGTH == X.size());

--- a/groups/bsl/bslstl/bslstl_unorderedmultimap.t.cpp
+++ b/groups/bsl/bslstl/bslstl_unorderedmultimap.t.cpp
@@ -380,13 +380,13 @@ struct CharToPairConverter {
         
         bsls::ObjectBuffer<KEY> tempKey;
         bsltf::TemplateTestFacility::emplace(
-                                       bsls::Util::addressOf(tempKey.object()),
+                                       BSLS_UTIL_ADDRESSOF(tempKey.object()),
                                        value,
                                        privateAllocator);
 
         bsls::ObjectBuffer<VALUE> tempValue;
         bsltf::TemplateTestFacility::emplace(
-                                     bsls::Util::addressOf(tempValue.object()),
+                                     BSLS_UTIL_ADDRESSOF(tempValue.object()),
                                      value - 'A' + '0',
                                      privateAllocator);
 

--- a/groups/bsl/bsltf/bsltf_nontypicaloverloadstesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_nontypicaloverloadstesttype.t.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
 // assertion:
 //..
           NonTypicalOverloadsTestType obj;
-          BSLS_ASSERTTEST_ASSERT_OPT_FAIL(delete bsls::Util::addressOf(obj));
+          BSLS_ASSERTTEST_ASSERT_OPT_FAIL(delete BSLS_UTIL_ADDRESSOF(obj));
 //..
 
       } break;
@@ -223,7 +223,7 @@ int main(int argc, char *argv[]) {
           BSLS_ASSERTTEST_ASSERT_OPT_FAIL(new NonTypicalOverloadsTestType());
 
           NonTypicalOverloadsTestType obj;
-          BSLS_ASSERTTEST_ASSERT_OPT_FAIL(delete bsls::Util::addressOf(obj));
+          BSLS_ASSERTTEST_ASSERT_OPT_FAIL(delete BSLS_UTIL_ADDRESSOF(obj));
 
 
           bslma::TestAllocator scratch("scratch", veryVeryVeryVerbose);
@@ -351,9 +351,9 @@ int main(int argc, char *argv[]) {
 
                 Obj mX(DATA2);
 
-                Obj *mR = bsls::Util::addressOf(mX = Z);
-                ASSERTV(ti, tj, mR, bsls::Util::addressOf(mX),
-                        mR == bsls::Util::addressOf(mX));
+                Obj *mR = BSLS_UTIL_ADDRESSOF(mX = Z);
+                ASSERTV(ti, tj, mR, BSLS_UTIL_ADDRESSOF(mX),
+                        mR == BSLS_UTIL_ADDRESSOF(mX));
 
                 ASSERTV(ti, tj, Z.data(), mX.data(), Z == mX);
                 ASSERTV(ti, tj, Z.data(), ZZ.data(), Z == ZZ);
@@ -370,9 +370,9 @@ int main(int argc, char *argv[]) {
             const Obj ZZ(DATA);
 
             const Obj& Z = mX;
-            Obj *mR = bsls::Util::addressOf(mX = Z);
-            ASSERTV(ti, mR, bsls::Util::addressOf(mX),
-                    mR == bsls::Util::addressOf(mX));
+            Obj *mR = BSLS_UTIL_ADDRESSOF(mX = Z);
+            ASSERTV(ti, mR, BSLS_UTIL_ADDRESSOF(mX),
+                    mR == BSLS_UTIL_ADDRESSOF(mX));
 
             ASSERTV(ti, Z.data(), mX.data(), Z == mX);
             ASSERTV(ti, Z.data(), ZZ.data(), Z == ZZ);

--- a/groups/bsl/bsltf/bsltf_stdtestallocator.h
+++ b/groups/bsl/bsltf/bsltf_stdtestallocator.h
@@ -480,7 +480,7 @@ inline
 typename StdTestAllocator<TYPE>::pointer
 StdTestAllocator<TYPE>::address(reference object) const
 {
-    return bsls::Util::addressOf(object);
+    return BSLS_UTIL_ADDRESSOF(object);
 }
 
 template <class TYPE>
@@ -488,7 +488,7 @@ inline
 typename StdTestAllocator<TYPE>::const_pointer
 StdTestAllocator<TYPE>::address(const_reference object) const
 {
-    return bsls::Util::addressOf(object);
+    return BSLS_UTIL_ADDRESSOF(object);
 }
 
 template <class TYPE>

--- a/groups/bsl/bsltf/bsltf_templatetestfacility.h
+++ b/groups/bsl/bsltf/bsltf_templatetestfacility.h
@@ -967,7 +967,7 @@ inline
 TYPE TemplateTestFacility::create(int identifier)
 {
     bsls::ObjectBuffer<TYPE> obj;
-    emplace(bsls::Util::addressOf(obj.object()),
+    emplace(BSLS_UTIL_ADDRESSOF(obj.object()),
             identifier,
             &bslma::MallocFreeAllocator::singleton());
     return obj.object();

--- a/groups/bsl/bsltf/bsltf_templatetestfacility.t.cpp
+++ b/groups/bsl/bsltf/bsltf_templatetestfacility.t.cpp
@@ -636,7 +636,7 @@ void TestHelper<TYPE>::test6Helper()
     bsls::ObjectBuffer<TYPE> buffer;
     TYPE &mX = buffer.object();
     const TYPE &X = mX;
-    TYPE *address = bsls::Util::addressOf(mX);
+    TYPE *address = BSLS_UTIL_ADDRESSOF(mX);
 
     for (int ti = 0; ti <= 127; ++ti) {
         TemplateTestFacility::emplace(address, ti, &objectAllocator);


### PR DESCRIPTION
replace calls to bsls::Util::addressOf() with BSLS_UTIL_ADDRESSOF()
where trivial to do so.  bsls::Util::addressOf() performs casting,
causing pointer aliasing, which can be a problem with optimization
if the result is dereferenced as a different type (instead of being
dereferenced after being cast back to the original type).
BSLS_UTIL_ADDRESSOF() wraps the call and uses '&' on platforms other
than Windows (due to MSFC needs).  See bsls_util.h for more details.

The following files continue to use bsls::Util::addressOf() and should be reviewed
bsl/bsltf/bsltf_degeneratefunctor.h
bsl/bslstl/bslstl_allocatortraits.t.cpp
bsl/bslstl/bslstl_hashtable.t.cpp
bsl/bslstl/bslstl_hashtable.h
