### PR TITLE
remove gcc -fno-strict-aliasing flag; not required

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -43,7 +43,7 @@
                              #'-std=c++0x', # gcc 4.6
                              #'-std=c++11', # gcc 4.7
                               '-pthread', ],       # thread aware (not optional)
-            'cflags_opt%': [ '-O2', '-fno-strict-aliasing', ],
+            'cflags_opt%': [ '-O2' ],
             'cflags_c_debug%':  [ '-g -fno-inline' ],
             'cflags_cc_debug%': [ '-g -fno-inline' ],
             'cflags_cc_exc%': [ '-fexceptions', ],


### PR DESCRIPTION
bsl test drivers pass x86 Linux gcc without -fno-strict-aliasing
