### PR TITLE
add branch prediction hints to bsls_bsltestutil

### DIFF
--- a/groups/bsl/bsls/bsls_bsltestutil.h
+++ b/groups/bsl/bsls/bsls_bsltestutil.h
@@ -420,7 +420,7 @@ BSLS_IDENT("$Id: $")
                        // =================
 
 #define BSLS_BSLTESTUTIL_ASSERT(X) {                                          \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 aSsErT(true, #X, __LINE__); } }
 
@@ -428,7 +428,7 @@ BSLS_IDENT("$Id: $")
     BSLS_BSLTESTUTIL_ASSERT
 
 #define BSLS_BSLTESTUTIL_LOOP_ASSERT(I,X) {                                   \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\n");          \
                 aSsErT(true, #X, __LINE__); } }
@@ -437,14 +437,14 @@ BSLS_IDENT("$Id: $")
     BSLS_BSLTESTUTIL_LOOP_ASSERT
 
 #define BSLS_BSLTESTUTIL_LOOP2_ASSERT(I,J,X) {                                \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\t");          \
                 bsls::BslTestUtil::callDebugprint(J, #J ": ", "\n");          \
                 aSsErT(true, #X, __LINE__); } }
 
 #define BSLS_BSLTESTUTIL_LOOP3_ASSERT(I,J,K,X) {                              \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\t");          \
                 bsls::BslTestUtil::callDebugprint(J, #J ": ", "\t");          \
@@ -452,7 +452,7 @@ BSLS_IDENT("$Id: $")
                 aSsErT(true, #X, __LINE__); } }
 
 #define BSLS_BSLTESTUTIL_LOOP4_ASSERT(I,J,K,L,X) {                            \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\t");          \
                 bsls::BslTestUtil::callDebugprint(J, #J ": ", "\t");          \
@@ -461,7 +461,7 @@ BSLS_IDENT("$Id: $")
                 aSsErT(true, #X, __LINE__); } }
 
 #define BSLS_BSLTESTUTIL_LOOP5_ASSERT(I,J,K,L,M,X) {                          \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\t");          \
                 bsls::BslTestUtil::callDebugprint(J, #J ": ", "\t");          \
@@ -471,7 +471,7 @@ BSLS_IDENT("$Id: $")
                 aSsErT(true, #X, __LINE__); } }
 
 #define BSLS_BSLTESTUTIL_LOOP6_ASSERT(I,J,K,L,M,N,X) {                        \
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!(X))) {                        \
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!((bool)(X)))) {                \
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;                           \
                 bsls::BslTestUtil::callDebugprint(I, #I ": ", "\t");          \
                 bsls::BslTestUtil::callDebugprint(J, #J ": ", "\t");          \

--- a/groups/bsl/bsltf/bsltf_evilbooleantype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_evilbooleantype.t.cpp
@@ -52,7 +52,7 @@ static void aSsErT(bool b, const char *s, int i)
 //                       STANDARD BDE TEST DRIVER MACROS
 //-----------------------------------------------------------------------------
 
-#define ASSERT(X)    BSLS_BSLTESTUTIL_ASSERT((bool)(X))
+#define ASSERT       BSLS_BSLTESTUTIL_ASSERT
 #define LOOP_ASSERT  BSLS_BSLTESTUTIL_LOOP_ASSERT
 #define LOOP0_ASSERT BSLS_BSLTESTUTIL_LOOP0_ASSERT
 #define LOOP1_ASSERT BSLS_BSLTESTUTIL_LOOP1_ASSERT


### PR DESCRIPTION
In general, the various BSLS_BSLTESTUTIL_ASSERT*() macros succeed and
so the compiler need not spend time optimizing unlikely failure cases
