### PR TITLE
remove xlC -qalias=noansi flag; workaround xlC new

### DIFF
--- a/groups/bsl/bslalg/bslalg_scalarprimitives.h
+++ b/groups/bsl/bslalg/bslalg_scalarprimitives.h
@@ -1336,7 +1336,8 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
 {
     BSLS_ASSERT_SAFE(address);
 
-    new (address) TARGET_TYPE();
+    ::new (address) TARGET_TYPE();
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1>
@@ -1371,6 +1372,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2>
@@ -1404,6 +1406,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3>
@@ -1437,6 +1440,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -1477,6 +1481,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -1519,6 +1524,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -1563,6 +1569,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -1609,6 +1616,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -1659,6 +1667,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -1711,6 +1720,7 @@ ScalarPrimitives::construct(TARGET_TYPE *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -1765,6 +1775,7 @@ ScalarPrimitives::construct(TARGET_TYPE  *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -1821,6 +1832,7 @@ ScalarPrimitives::construct(TARGET_TYPE  *address,
     BSLS_ASSERT_SAFE(address);
 
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -1882,6 +1894,7 @@ ScalarPrimitives::construct(TARGET_TYPE  *address,
 
     ::new (address) TARGET_TYPE(a1,  a2,  a3, a4, a5, a6, a7, a8, a9,
                                 a10, a11, a12);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1, typename ARG2,  typename ARG3,
@@ -1945,6 +1958,7 @@ ScalarPrimitives::construct(TARGET_TYPE  *address,
 
     ::new (address) TARGET_TYPE(
                        a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1,  typename ARG2,  typename ARG3,
@@ -2010,6 +2024,7 @@ ScalarPrimitives::construct(TARGET_TYPE  *address,
 
     ::new (address) TARGET_TYPE(
                   a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 }  // close package namespace
@@ -2056,6 +2071,7 @@ ScalarPrimitives_Imp::defaultConstruct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE>
@@ -2097,6 +2113,7 @@ ScalarPrimitives_Imp::defaultConstruct(TARGET_TYPE                *address,
                                        bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE();
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE>
@@ -2113,6 +2130,7 @@ ScalarPrimitives_Imp::defaultConstruct(
         // assignment can't throw.
 
         ::new (address) TARGET_TYPE();
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
     } else {
         std::memset((char *)address, 0, sizeof *address);
     }
@@ -2125,6 +2143,7 @@ ScalarPrimitives_Imp::defaultConstruct(TARGET_TYPE                *address,
                                        bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE();
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
                       // *** copyConstruct overloads: ***
@@ -2139,6 +2158,7 @@ ScalarPrimitives_Imp::copyConstruct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(original, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE>
@@ -2181,6 +2201,7 @@ ScalarPrimitives_Imp::copyConstruct(
         // is 'const'-qualified.
 
         ::new (address) TARGET_TYPE(original);
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
     } else {
         std::memcpy(address, BSLS_UTIL_ADDRESSOF(original), sizeof original);
     }
@@ -2195,6 +2216,7 @@ ScalarPrimitives_Imp::copyConstruct(TARGET_TYPE                *address,
                                     bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(original);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE>
@@ -2214,6 +2236,7 @@ ScalarPrimitives_Imp::copyConstruct(
         // is 'const'-qualified.
 
         ::new (address) TARGET_TYPE(original);
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
     } else {
         std::memcpy(address, BSLS_UTIL_ADDRESSOF(original), sizeof original);
     }
@@ -2227,6 +2250,7 @@ ScalarPrimitives_Imp::copyConstruct(TARGET_TYPE                *address,
                                     bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(original);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
                      // *** destructiveMove overloads: ***
@@ -2249,6 +2273,7 @@ ScalarPrimitives_Imp::destructiveMove(
         // is 'const'-qualified.
 
         ::new (address) TARGET_TYPE(*original);
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
     } else {
         std::memcpy(address, original, sizeof *original);   // no overlap
     }
@@ -2286,6 +2311,7 @@ ScalarPrimitives_Imp::construct(
         // is 'const'-qualified.
 
         ::new (address) TARGET_TYPE(a1);
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
     } else {
         BSLMF_ASSERT(sizeof (TARGET_TYPE) == sizeof(a1));
         std::memcpy(address, BSLS_UTIL_ADDRESSOF(a1), sizeof a1); // no overlap
@@ -2341,7 +2367,8 @@ ScalarPrimitives_Imp::construct(
                         bslma::Allocator                            *allocator,
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
-    new (address) TARGET_TYPE(allocator);
+    ::new (address) TARGET_TYPE(allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE>
@@ -2351,7 +2378,8 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslma::Allocator           *,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
-    new (address) TARGET_TYPE();
+    ::new (address) TARGET_TYPE();
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1>
@@ -2364,6 +2392,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1>
@@ -2375,6 +2404,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2>
@@ -2388,6 +2418,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2>
@@ -2400,6 +2431,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3>
@@ -2414,6 +2446,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3>
@@ -2427,6 +2460,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2443,6 +2477,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2458,6 +2493,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2475,6 +2511,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2491,6 +2528,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2509,6 +2547,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2526,6 +2565,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2545,6 +2585,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2, typename ARG3,
@@ -2563,6 +2604,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2584,6 +2626,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2604,6 +2647,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2626,6 +2670,7 @@ ScalarPrimitives_Imp::construct(
                         bslmf::MetaInt<USES_BSLMA_ALLOCATOR_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2647,6 +2692,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2671,6 +2717,7 @@ ScalarPrimitives_Imp::construct(
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
                                 allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2693,6 +2740,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2718,6 +2766,7 @@ ScalarPrimitives_Imp::construct(
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11,
                                 allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2741,6 +2790,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
                                 bslmf::MetaInt<NIL_TRAITS> *)
 {
     ::new (address) TARGET_TYPE(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2769,6 +2819,7 @@ ScalarPrimitives_Imp::construct(
     ::new (address) TARGET_TYPE(
                              a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12,
                              allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE, typename ARG1, typename ARG2,  typename ARG3,
@@ -2795,6 +2846,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
 {
     ::new (address) TARGET_TYPE(
                             a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1, typename ARG2,  typename ARG3,
@@ -2824,6 +2876,7 @@ ScalarPrimitives_Imp::construct(
     ::new (address) TARGET_TYPE(
                         a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13,
                         allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1, typename ARG2,  typename ARG3,
@@ -2851,6 +2904,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
 {
     ::new (address) TARGET_TYPE(
                        a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1,  typename ARG2,  typename ARG3,
@@ -2881,6 +2935,7 @@ ScalarPrimitives_Imp::construct(
     ::new (address) TARGET_TYPE(
                    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14,
                    allocator);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
 template <typename TARGET_TYPE,  typename ARG1,  typename ARG2,  typename ARG3,
@@ -2909,6 +2964,7 @@ ScalarPrimitives_Imp::construct(TARGET_TYPE                *address,
 {
     ::new (address) TARGET_TYPE(
                   a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14);
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 }
 
                           // *** swap overloads: ***

--- a/groups/bsl/bslma/bslma_destructorguard.t.cpp
+++ b/groups/bsl/bslma/bslma_destructorguard.t.cpp
@@ -137,6 +137,7 @@ double usageExample(double startValue)
     else {
         new (&myVec) std::vector<double>();
     }
+    BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
 
     //***********************************************************
     // Note the use of the destructor guard on 'myVec' (below). *

--- a/groups/bsl/bsls/bsls_performancehint.h
+++ b/groups/bsl/bsls/bsls_performancehint.h
@@ -405,6 +405,23 @@ namespace BloombergLP {
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT
 #endif
 
+#if defined(BSLS_PLATFORM_CMP_IBM)
+    #define BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE                           \
+                             __fence()
+    #define BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE                          \
+                             BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE
+#elif defined(BSLS_PLATFORM_CMP_MSVC)
+    #include <intrin.h>
+    #pragma intrinsic(_ReadWriteBarrier)
+    #define BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE                           \
+                             _ReadWriteBarrier()
+    #define BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE
+#else
+    #define BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE                           \
+                             asm volatile ("":::"memory")
+    #define BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE
+#endif
+
 namespace bsls {
 
                         // ======================

--- a/groups/bsl/bsls/bsls_performancehint.h
+++ b/groups/bsl/bsls/bsls_performancehint.h
@@ -436,14 +436,14 @@ namespace BloombergLP {
 #endif
 
 // Workaround for optimization issue in xlC that mishandles pointer aliasing.
+//   IV56864: ALIASING BEHAVIOUR FOR PLACEMENT NEW
+//   http://www-01.ibm.com/support/docview.wss?uid=swg1IV56864
 // Place this macro following each use of placment new.  Alternatively,
 // compile with xlC_r -qalias=noansi, which reduces optimization opportunities
 // across entire translation unit instead of simply across optimization fence.
-// Issue appears to be fixed in xlC 12.1.  When fix is confirmed from IBM, then
-// BSLS_PLATFORM_CMP_VERSION can be checked and macro made a no-op in later
-// versions of xlC compiler.
+// Update: issue is fixed in xlC 13.1 (__xlC__ >= 0x0d01).
 
-#if defined(BSLS_PLATFORM_CMP_IBM)
+#if defined(BSLS_PLATFORM_CMP_IBM) && BSLS_PLATFORM_CMP_VERSION < 0x0d01
     #define BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE                          \
                              BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE
 #else

--- a/groups/bsl/bsls/bsls_performancehint.t.cpp
+++ b/groups/bsl/bsls/bsls_performancehint.t.cpp
@@ -287,6 +287,7 @@ void testUsageExample1(int argc, bool assert)
     int verbose = argc > 2;
     int veryVerbose = argc > 3;
     int veryVeryVerbose = argc > 4;
+    double tolerance = 0.02;
 
     (void) assert;
     (void) verbose;
@@ -363,8 +364,6 @@ void testUsageExample1(int argc, bool assert)
     // 'BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY' expands into something
     // meaningful.
 
-    double tolerance = 0.02;
-
     if (assert) {
         LOOP2_ASSERT(likelyTime, unlikelyTime,
                      likelyTime + tolerance > unlikelyTime);
@@ -372,6 +371,53 @@ void testUsageExample1(int argc, bool assert)
 
 #endif
 
+#endif
+
+    int z;
+    timer.reset();
+
+    if (veryVerbose) {
+        cout << "BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE" << endl;
+    }
+
+    timer.start();
+
+    z = 0;
+    for (int x = 0; x < TESTSIZE; ++x) {
+        ++z;
+        BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE;
+    }
+
+    timer.stop();
+    double timeWithOptFence = timer.elapsedTime();
+
+    if (veryVerbose) {
+        cout << "\ttime = " << timeWithOptFence << endl;
+    }
+
+
+    if (veryVerbose) {
+        cout << "without BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE" << endl;
+    }
+
+    timer.reset();
+    timer.start();
+
+    z = 0;
+    for (int x = 0; x < TESTSIZE; ++x) {
+        ++z;
+    }
+    timer.stop();
+    double timeWithoutOptFence = timer.elapsedTime();
+
+    if (veryVerbose) {
+        cout << "\ttime = " << timeWithoutOptFence << endl;
+    }
+
+#if defined(BDE_BUILD_TARGET_OPT)
+    // Only check under optimized build.
+    LOOP2_ASSERT(timeWithOptFence, timeWithoutOptFence,
+                 timeWithOptFence + tolerance > timeWithoutOptFence);
 #endif
 }
 
@@ -630,13 +676,19 @@ int main(int argc, char *argv[])
         // Testing:
         //   BSLS_PERFORMANCEHINT_PREDICT_LIKELY,
         //   BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY
+        //   BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE
+        //   BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE
         // --------------------------------------------------------------------
 
         if (verbose) printf("\nTESTING USAGE EXAMPLE 1"
                             "\n=======================\n");
 
+        // Simple test that macros expand to compilable code; not usage example
+        BSLS_PERFORMANCEHINT_OPTIMIZATION_FENCE;
+        BSLS_PERFORMANCEHINT_PLACEMENT_NEW_FENCE;
+
         ASSERT(true);
-        TestCase1::testUsageExample1(argc, false);
+        TestCase1::testUsageExample1(argc, true);
 
       } break;
       case 1: {


### PR DESCRIPTION
xlC placement new operator is inlined and does not appear to
interoperate well with bsls_objectbuffer.  However,
  #define __IBM_ALLOW_OVERRIDE_PLACEMENT_NEW
allows bsl test drivers to pass POWER AIX xlC without -qalias=noansi
except for bsltf_templatetestfacility.t.cpp.  Alternatively, the
introduction of a compiler optimization fence (xlC __fence())
following each call to placement new in bslalg_scalarprimitives.h
and in bslma_destructorguard.t.cpp allows all bsl test drivers to pass.
Using both workarounds is recommended until the interaction between
bsls_objectbuffer and xlC placement new is understood more precisely.

IBM documents #define __IBM_ALLOW_OVERRIDE_PLACEMENT_NEW as follows:
"Can be used to obtain the behavior of global placement new operators.
 By default, this macro is not predefined, and the Standard C++ Library
 provides the inlined version of global placement new operators, which
 can assist with improving performance."