### PR TITLE
do not define __unix in common.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -94,7 +94,7 @@
 
           # IBM Visual Age xlC
           [ 'compiler_tag == "xlC"', {
-            'defines_base': [ '__unix',
+            'defines_base': [
                               '__VACPP_MULTI__',   # thread aware (or use xlC_r)
                               # (optional) see "xlC streams optimization" below
                               #'__NOLOCK_ON_INPUT', '__NOLOCK_ON_OUTPUT',
@@ -195,9 +195,6 @@
 
 
           [ 'OS == "mac"', {
-            'defines_base': [
-              '__unix',              # xcodebuild/clang does not define __unix
-            ],
             'cflags_abi_32=': [ 'i386' ],
             'cflags_abi_64=': [ 'x86_64' ],
           }],


### PR DESCRIPTION
xlC defines both **unix and __unix**
(gcc on AIX did not define these in gcc versions prior to 4.7.0)
xcodebuild/clang does -not- define **unix or __unix**,
but bsl/bsls/bsls_platform.h is being modified to not require them
(Depends on https://github.com/bloomberg/bsl/issues/97)  (This patch also follows up on https://github.com/bloomberg/bsl/issues/74)
