### PR TITLE
tune g++ to reduce mem usage

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -39,7 +39,8 @@
 
           # GNU gcc
           [ 'compiler_tag == "gcc"', {
-            'cflags_base%': [ '-pipe', # uncomment -std= to specify compiler std
+            'cflags_base%': [ '--param', 'ggc-min-expand=50',
+                              '-pipe', # uncomment -std= to specify compiler std
                              #'-std=c++0x', # gcc 4.6
                              #'-std=c++11', # gcc 4.7
                               '-pthread', ],       # thread aware (not optional)


### PR DESCRIPTION
g++ takes over 3 GB to compile bslstl_hashtable.t.cpp
'g++ --param ggc-min-expand=50' lowers this to about 2 GB by running
the g++ internal garbage collection more frequently than the default.
On a dual-core laptop with 4 GB of memory and no swap space, building
with make -j 3 was successful, though building with make -j 4 thrashed
due to increased memory demands of extra job.  make -j 3 combined with
g++ --param gcc-min-expand=30 was both faster and took less CPU than
building with make -j 4 combined with g++ --param ggc-min-expand=30.

This pull request, combined with https://github.com/bloomberg/bsl/pull/91 should adequately addess https://github.com/bloomberg/bsl/issues/90.
