### PR TITLE
Fix compilation on Xcode 5.0.2

### DIFF
--- a/groups/bsl/bsl+bslhdrs/bsl_ios.h
+++ b/groups/bsl/bsl+bslhdrs/bsl_ios.h
@@ -25,7 +25,21 @@ BSLS_IDENT("$Id: $")
 #include <bsls_platform.h>
 #endif
 
+#ifdef BSLS_PLATFORM_OS_DARWIN  // on Darwin, 'num_get' comes from <locale>
+
+#ifndef INCLUDED_LOCALE
+#include <locale>
+#define INCLUDED_LOCALE
+#endif
+
+#else
+
+#ifndef INCLUDED_IOS
 #include <ios>
+#define INCLUDED_IOS
+#endif
+
+#endif
 
 namespace bsl
 {

--- a/groups/bsl/bsls/bsls_timeutil.h
+++ b/groups/bsl/bsls/bsls_timeutil.h
@@ -203,7 +203,8 @@ BSLS_IDENT("$Id: $")
     #endif
 #endif
 
-#if defined(BSLS_PLATFORM_OS_AIX) || defined(BSLS_PLATFORM_OS_FREEBSD)
+#if defined(BSLS_PLATFORM_OS_AIX) || defined(BSLS_PLATFORM_OS_FREEBSD) \
+                                  || defined(BSLS_PLATFORM_OS_DARWIN)
     #ifndef INCLUDED_SYS_TIME
     #include <sys/time.h>
     #define INCLUDED_SYS_TIME

--- a/groups/bsl/bslstl/bslstl_iosfwd.h
+++ b/groups/bsl/bslstl/bslstl_iosfwd.h
@@ -34,11 +34,10 @@ BSLS_IDENT("$Id: $")
 #include <bslscm_version.h>
 #endif
 
-namespace std {
-
-template <class CHAR_TYPE> struct char_traits;
-
-}  // close namespace std
+#ifndef INCLUDED_IOSFWD
+#include <iosfwd>
+#define INCLUDED_IOSFWD
+#endif
 
 namespace bsl {
 


### PR DESCRIPTION
This fixes Issue #92. In particular, 3 changes were required:
- include `<locale>` instead of `<ios>` to get `std::num_get` in `bsl_ios.h`.
- include `<sys/time.h>` instead of `<time.h>` to get platform-specific types related to time (making Darwin more like FreeBSD and AIX in this regard).
- include `<iosfwd>` in `bsls_iosfwd.h` instead of attempting to forward declare `std::char_traits`.  The latter proves difficult since we cannot guarantee, in general, the ordering of `bsl_iosfwd.h` and `bsl_string.h`.  The latter would pull in `<string>` which would define it and clash with the definition provided in `bsl_iosfwd.h`.

I am aware there is an [ongoing review](https://review.openbloomberg.com/D56) for these fixes; I believe my pull request addresses concerns raised in that review.

Needless to say, all tests passed.
