### PR TITLE
bsls_timeutil: Support Mach high-resolution monotonic clock.

### DIFF
--- a/groups/bsl/bsls/bsls_timeutil.h
+++ b/groups/bsl/bsls/bsls_timeutil.h
@@ -231,9 +231,11 @@ struct TimeUtil {
 #elif defined BSLS_PLATFORM_OS_AIX
     typedef timebasestruct_t                  OpaqueNativeTime;
 #elif defined BSLS_PLATFORM_OS_HPUX
-        typedef struct { Types::Int64 d_opaque; } OpaqueNativeTime;
+    typedef struct { Types::Int64 d_opaque; } OpaqueNativeTime;
 #elif defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_CYGWIN)
-        typedef timespec                          OpaqueNativeTime;
+    typedef timespec                          OpaqueNativeTime;
+#elif defined BSLS_PLATFORM_OS_DARWIN
+    typedef struct { Types::Int64 d_opaque; } OpaqueNativeTime;
 #elif defined BSLS_PLATFORM_OS_UNIX
     typedef timeval                           OpaqueNativeTime;
 #elif defined BSLS_PLATFORM_OS_WINDOWS


### PR DESCRIPTION
Adds platform-specific support for the Mach kernel high-resolution
monotonic timer when BSLS_PLATFORM_OS_DARWIN is defined.
