### PR TITLE
Fixed bufferallocator example:

### DIFF
--- a/samples/buffer_allocator/bufferallocator.cpp
+++ b/samples/buffer_allocator/bufferallocator.cpp
@@ -12,13 +12,13 @@ namespace pkg {
                         // ---------------------
 
 // MANIPULATORS
-void *BufferAllocator::allocate(bsls_Types::size_type size)
+void *BufferAllocator::allocate(bsls::Types::size_type size)
 {
     BSLS_ASSERT_SAFE(0 <= size);
 
     // Calculate the appropriate aligned offset
 
-    const int offset = bsls_AlignmentUtil::calculateAlignmentOffset(
+    const int offset = bsls::AlignmentUtil::calculateAlignmentOffset(
                                   d_buffer_p + d_cursor,
                                       bsls::AlignmentUtil::BSLS_MAX_ALIGNMENT);
 

--- a/samples/buffer_allocator/bufferallocator.h
+++ b/samples/buffer_allocator/bufferallocator.h
@@ -90,7 +90,7 @@ class BufferAllocator : public bslma::Allocator {
         // incurred.
 
     // MANIPULATORS
-    virtual void *allocate(bsls_Types::size_type size);
+    virtual void *allocate(bsls::Types::size_type size);
         // Return the address of a contiguous block of maximally-aligned memory
         // of the specified 'size' (in bytes).  If 'size' is 0 no memory is
         // allocated and 0 is returned.  If the allocation request exceeds the
@@ -118,6 +118,7 @@ BufferAllocator::BufferAllocator(char             *buffer,
                                  bslma::Allocator *basicAllocator)
 : d_buffer_p(buffer)
 , d_bufferSize(bufferSize)
+, d_cursor(0)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }


### PR DESCRIPTION
The example does not compile due to wrong namespacing, and has an uninitialized data member in the constructor.  This pull request addresses both defects.
