### PR TITLE
Supports building with a mingw32 toolchain

### DIFF
--- a/groups/bsl/bsls/bsls_atomicoperations_x86_all_gcc.t.cpp
+++ b/groups/bsl/bsls/bsls_atomicoperations_x86_all_gcc.t.cpp
@@ -55,7 +55,7 @@ bsls::Types::Int64 getTimerMs() {
 #elif defined(BSLS_PLATFORM_OS_WINDOWS)
     timeb t;
     ::ftime(&t);
-    return = static_cast<bsls::Types::Int64>(t.time) * 1000 + t.millitm;
+    return static_cast<bsls::Types::Int64>(t.time) * 1000 + t.millitm;
 #else
 #error "Don't know how to get timer for this platform"
 #endif

--- a/groups/bsl/bsls/bsls_bsllock.h
+++ b/groups/bsl/bsls/bsls_bsllock.h
@@ -118,12 +118,12 @@ BSLS_IDENT("$Id: $")
 #ifdef BSLS_PLATFORM_OS_WINDOWS
 
 #ifndef INCLUDED_WTYPES
-#include <WTypes.h>
+#include <wtypes.h>
 #define INCLUDED_WTYPES
 #endif
 
 #ifndef INCLUDED_WINBASE
-#include <WinBase.h>
+#include <winbase.h>
 #define INCLUDED_WINBASE
 #endif
 

--- a/groups/bsl/bsls/bsls_platform.h
+++ b/groups/bsl/bsls/bsls_platform.h
@@ -744,7 +744,7 @@ struct bsls_Platform_Assert;
 #endif
 
 // MSVC and Windows
-#elif defined(BSLS_PLATFORM_CMP_MSVC) && defined(BSLS_PLATFORM_OS_WINDOWS)
+#elif defined(BSLS_PLATFORM_OS_WINDOWS)
 #   define BSLS_PLATFORM_IS_LITTLE_ENDIAN 1
 #endif
 


### PR DESCRIPTION
Requires minimal changes to `bsls_platform` detect if the toolchain is a GNU toolchain but running on windows.

All tests on Linux pass. I was unable to get `master` cleanly building on Windows.
