### PR TITLE
bsls_annotation: _CMP_CLANG and documentation fix

### DIFF
--- a/groups/bsl/bsls/bsls_annotation.h
+++ b/groups/bsl/bsls/bsls_annotation.h
@@ -25,6 +25,8 @@ BSLS_IDENT("$Id: $")
 //  BSLS_ANNOTATION_NULL_TERMINATED_AT(x): warn if argument at 'x' is non-NULL
 //  BSLS_ANNOTATION_WARN_UNUSED_RESULT: warn if annotated function result used
 //  BSLS_ANNOTATION_DEPRECATED: warn if annotated entity is used
+//  BSLS_ANNOTATION_USED: emit annotated entity even if not referenced
+//  BSLS_ANNOTATION_UNUSED: do not warn if annotated entity is unused
 //
 //@DESCRIPTION: This component provides a suite of preprocessor macros that
 // define compiler-specific compile-time annotations.  These macros, which
@@ -32,9 +34,10 @@ BSLS_IDENT("$Id: $")
 // specific compile-time safety checks.
 //
 // For the most part, these compile-time annotations are supported only when
-// the 'BSLS_PLATFORM_CMP_GNU' preprocessor macro is defined.  Other compilers
-// may implement a few annotations, but the macros should be expected to work
-// only with compilers for which 'BSLS_PLATFORM_CMP_GNU' is defined.
+// the 'BSLS_PLATFORM_CMP_GNU' or 'BSLS_PLATFORM_CMP_CLANG' preprocessor macro
+// is defined.  Other compilers may implement a few annotations, but the macros
+// should be expected to work only with compilers for which
+// 'BSLS_PLATFORM_CMP_GNU' or 'BSLS_PLATFORM_CMP_CLANG' is defined.
 //
 ///Function Annotations
 ///--------------------
@@ -49,7 +52,7 @@ BSLS_IDENT("$Id: $")
 // size (in bytes) is given by one or two of the function parameters.  Certain
 // compilers use this information to improve the correctness of built-in
 // object-size functions (e.g., '__builtin_object_size' with
-// 'BSLS_PLATFORM_CMP_GNU').
+// 'BSLS_PLATFORM_CMP_GNU' or 'BSLS_PLATFORM_CMP_CLANG').
 //
 // The function parameter(s) denoting the size of the block are specified by
 // one or two integer arguments supplied to the macro.  The allocated size (in
@@ -159,6 +162,12 @@ BSLS_IDENT("$Id: $")
 // In the above code, the third line results in a compiler warning.
 //
 //..
+//  BSLS_ANNOTATION_USED
+//..
+// This annotation indicates that the so-annotated function, variable, or type
+// must be emitted even if it appears that the variable is not referenced.
+//
+//..
 //  BSLS_ANNOTATION_UNUSED
 //..
 // This annotation indicates that the so-annotated function, variable, or type
@@ -185,7 +194,7 @@ BSLS_IDENT("$Id: $")
 #include <bsls_platform.h>
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU)
+#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_USED       __attribute__((__used__))
     #define BSLS_ANNOTATION_UNUSED     __attribute__((__unused__))
     #define BSLS_ANNOTATION_ERROR(x)   __attribute__((__error__(x)))
@@ -197,7 +206,8 @@ BSLS_IDENT("$Id: $")
     #define BSLS_ANNOTATION_WARNING(x)
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 40300
+#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 40300) || \
+    defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_ALLOC_SIZE(x) __attribute__((__alloc_size__(x)))
     #define BSLS_ANNOTATION_ALLOC_SIZE_MUL(x, y) \
                                           __attribute__((__alloc_size__(x, y)))
@@ -206,7 +216,7 @@ BSLS_IDENT("$Id: $")
     #define BSLS_ANNOTATION_ALLOC_SIZE_MUL(x, y)
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 30300
+#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_ARG_NON_NULL(...) \
                                       __attribute__((__nonnull__(__VA_ARGS__)))
     #define BSLS_ANNOTATION_ARGS_NON_NULL     \
@@ -216,19 +226,21 @@ BSLS_IDENT("$Id: $")
     #define BSLS_ANNOTATION_ARGS_NON_NULL
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 30100
+#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_DEPRECATED __attribute__((__deprecated__))
 #else
     #define BSLS_ANNOTATION_DEPRECATED
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_IBM)
+#if defined(BSLS_PLATFORM_CMP_GNU)   || \
+    defined(BSLS_PLATFORM_CMP_CLANG) || \
+    defined(BSLS_PLATFORM_CMP_IBM)
     #define BSLS_ANNOTATION_FORMAT(arg) __attribute__((format_arg(arg)))
 #else
     #define BSLS_ANNOTATION_FORMAT(arg)
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 40000
+#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_NULL_TERMINATED __attribute__((__sentinel__))
     #define BSLS_ANNOTATION_NULL_TERMINATED_AT(x) \
                                             __attribute__((__sentinel__(x)))
@@ -237,8 +249,9 @@ BSLS_IDENT("$Id: $")
     #define BSLS_ANNOTATION_NULL_TERMINATED_AT(x)
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) || \
-    defined(BSLS_PLATFORM_CMP_HP)  || \
+#if defined(BSLS_PLATFORM_CMP_GNU)   || \
+    defined(BSLS_PLATFORM_CMP_CLANG) || \
+    defined(BSLS_PLATFORM_CMP_HP)    || \
     defined(BSLS_PLATFORM_CMP_IBM)
     #define BSLS_ANNOTATION_PRINTF(fmt, arg) \
                                       __attribute__((format(printf, fmt, arg)))
@@ -249,7 +262,7 @@ BSLS_IDENT("$Id: $")
     #define BSLS_ANNOTATION_SCANF(fmt, arg)
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VER_MAJOR >= 30400
+#if defined(BSLS_PLATFORM_CMP_GNU) || defined(BSLS_PLATFORM_CMP_CLANG)
     #define BSLS_ANNOTATION_WARN_UNUSED_RESULT \
                                             __attribute__((warn_unused_result))
 #else


### PR DESCRIPTION
Explicitly add mention and support for 'BSLS_PLATFORM_CMP_CLANG'
instead of relying on 'BSLS_PLATFORM_CMP_GNU' to be set since Clang
supports the full set of GCC attributes.

Fix documentation to add _USED and _UNUSED to @MACROS list.

(The older GCC version checks < 4.3 are removed since BDE won't build with older compilers anyway)
