### PR TITLE
Provides includes for used names

### DIFF
--- a/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalconvertutil.cpp
@@ -20,6 +20,7 @@ BSLS_IDENT("$Id$")
 #include <math.h>
 
 #include <bsl_algorithm.h>
+#include <bsl_cstring.h>
 #include <bsl_iostream.h>  // TODO TBD - remove this, it is just for debugging
 #include <bsl_cstring.h>
 

--- a/groups/bdl/bdldfp/bdldfp_decimalplatform.t.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalplatform.t.cpp
@@ -4,15 +4,17 @@
 
 #include <bsl_iostream.h>
 #include <bsl_cstdlib.h>
+#include <bsl_cstring.h>
 
 #include <bslmf_issame.h>
 
 using namespace BloombergLP;
-using bsl::cout;
-using bsl::cerr;
-using bsl::flush;
-using bsl::endl;
 using bsl::atoi;
+using bsl::cerr;
+using bsl::cout;
+using bsl::endl;
+using bsl::flush;
+using bsl::memcmp;
 
 // ============================================================================
 //                                 TEST PLAN


### PR DESCRIPTION
This commit fixes the fact that some of the components/tests in `bdl` are using names exported from the system C headers without including them.

All tests build and pass on Linux.
