### PR TITLE
update configure instructions for waf build

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ used to configure and build the BDE repository:
 1. From the root of this source repository, run:
 
    ```shell
-   python waf configure
+   waf configure
    ```
 
 2. To build the libraries, but not the test drivers, run:


### PR DESCRIPTION
Since `waf` is now provided through the bde-tools repository, running
`python waf configure` fails.  This change updates the documentation for
the configuration step since `waf` will now be found in `PATH`.
