### PR TITLE
suppress unused expression result warning

### DIFF
--- a/groups/bsl/bsls/bsls_unspecifiedbool.t.cpp
+++ b/groups/bsl/bsls/bsls_unspecifiedbool.t.cpp
@@ -521,13 +521,12 @@ int main(int argc, char *argv[])
 
             if (veryVerbose) printf("\t\t1.12 Comma operator\n");
 
-            // Note that gcc will give a warning if the left-hand side of a
-            // comma operator is an expression with no effect.  The expression
-            // '(tmp == true)', used instead of 'true' below, is sufficiently
-            // complex to avoid the warning.
+            // Note that compilers (i.e., gcc and clang) will give a warning if
+            // the left-hand side of a comma operator computes a result that is
+            // not explicitly used or contains no side effects.  gcc recommends
+            // casting the unused expression to 'void'.
 
-            bool tmp = true;
-            bool bx = ((tmp == true), bt);
+            bool bx = (static_cast<void>(true), bt);
             ASSERT(!bx);
 
         }
@@ -723,13 +722,12 @@ int main(int argc, char *argv[])
 
             if (veryVerbose) printf("\t\t6.12 Comma operator\n");
 
-            // Note that gcc will give a warning if the left-hand side of a
-            // comma operator is an expression with no effect.  The expression
-            // '(tmp == true)', used instead of 'true' below, is sufficiently
-            // complex to avoid the warning.
+            // Note that compilers (i.e., gcc and clang) will give a warning if
+            // the left-hand side of a comma operator computes a result that is
+            // not explicitly used or contains no side effects.  gcc recommends
+            // casting the unused expression to 'void'.
 
-            bool tmp = true;
-            bool bx = ((tmp == true), babel);
+            bool bx = (static_cast<void>(true), babel);
             ASSERT(!bx);
         }
       } break;


### PR DESCRIPTION
In the bsls_unspecified.t.cpp test driver when compiled with clang, the
following would result with -Wunused-value being emitted:

  bool tmp = true;
  bool var = ((tmp == true), \<some-unspecified-bool-object\>);

One solution is to have the left-hand side of the comma operator to have
a side-effect (e.g., assignment of tmp).  However, in this change, per
gcc's documentation for -Wunused-value, the left-hand side of the comma
operator is cast to 'void' to suppress the warning.