### PR TITLE
On Windows platforms, wchar_t is 2 bytes.

### DIFF
--- a/groups/bsl/bsls/bsls_byteorderutil.h
+++ b/groups/bsl/bsls/bsls_byteorderutil.h
@@ -174,7 +174,7 @@ signed char ByteOrderUtil::swapBytes(signed char x)
 inline
 wchar_t ByteOrderUtil::swapBytes(wchar_t x)
 {
-#if defined(BSLS_PLATFORM_CMP_MSVC) ||                                        \
+#if defined(BSLS_PLATFORM_OS_WINDOWS) ||                                      \
     (defined(BSLS_PLATFORM_CPU_POWERPC) && defined(BSLS_PLATFORM_CPU_32_BIT))
     BSLS_BYTEORDERUTIL_COMPILE_TIME_ASSERT(2 == sizeof x);
 


### PR DESCRIPTION
'bsls_byteorderutil' wrongly assumes that only the 'MSVC' compiler treats 'wchar_t' as being 2 bytes, when it is safer to assume that all compilers on the 'Windows' platforms treat it so.  This commit amends the assumption.
