### PR TITLE
Update construction of MyTestObjectFactory in bslstl_sharedptr.t.cpp

### DIFF
--- a/groups/bsl/bslstl/bslstl_sharedptr.t.cpp
+++ b/groups/bsl/bslstl/bslstl_sharedptr.t.cpp
@@ -1815,8 +1815,8 @@ MyTestObjectFactory::MyTestObjectFactory()
 {
 }
 
-MyTestObjectFactory::MyTestObjectFactory(bslma::Allocator* /*basicAllocator*/)
-: d_allocator_p(bslma::Default::allocator(d_allocator_p))
+MyTestObjectFactory::MyTestObjectFactory(bslma::Allocator* basicAllocator)
+: d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
 


### PR DESCRIPTION
The construction of MyTestObjectFactory in bslstl_sharedptr.t.cpp does not take in the passed allocator. As discussed in bloomberg/bde/issues/129. Fixing this by passing the provided allocator into the member's construction.
