### PR TITLE
Hashtable format spec

### DIFF
--- a/groups/bsl/bslstl/bslstl_hashtable.t.cpp
+++ b/groups/bsl/bslstl/bslstl_hashtable.t.cpp
@@ -1659,7 +1659,7 @@ if (verbose) {
                                     bsl::distance(result.first, result.second);
 
 if (verbose) {
-            printf("customerId %d, count %d\n", customerId, count);
+            printf("customerId %d, count " BSLS_BSLTESTUTIL_FORMAT_TD "\n", customerId, count);
 }
 
             for (MySalesRecordContainer::ConstItrById itr  = result.first,
@@ -1702,7 +1702,7 @@ if (verbose) {
                 MySalesRecordContainer::ConstItrById>::difference_type count =
                                     bsl::distance(result.first, result.second);
 if (verbose) {
-            printf("vendorId %d, count %d\n", vendorId, count);
+            printf("vendorId %d, count " BSLS_BSLTESTUTIL_FORMAT_TD "\n", vendorId, count);
 }
 
             for (MySalesRecordContainer::ConstItrById itr  = result.first,


### PR DESCRIPTION
Fix for bloomberg/bde/issues/128 where the format specifier in the printf causes a compiler error under 32 bit compilation on Darwin.
