### PR TITLE
Fix bslstl::shared_ptr build in -std=c++11 due to typo.

### DIFF
--- a/groups/bsl/bslstl/bslstl_sharedptr.h
+++ b/groups/bsl/bslstl/bslstl_sharedptr.h
@@ -4961,7 +4961,7 @@ bsl::allocate_shared(ALLOC *a, const ARGS&... args)
 }
 
 template<class ELEMENT_TYPE, class... ARGS>
-bsl::shared_ptr<ELEMENT_TYPE> bsl::make_shared(const ARGS&... args);
+bsl::shared_ptr<ELEMENT_TYPE> bsl::make_shared(const ARGS&... args)
 {
     typedef BloombergLP::bslma::SharedPtrInplaceRep<ELEMENT_TYPE> Rep;
     BloombergLP::bslma::Allocator *basicAllocator =


### PR DESCRIPTION
Somehow a spurious semi-colon wound up in the header definition of one of the functions. Caused compilation error in `-std=c++11` mode:

```
bde/groups/bsl/bslstl/bslstl_sharedptr.h:4965:1: error: expected unqualified-id
{
^
```
