### PR TITLE
bslim_printer: Support printing StringRef values.

### DIFF
--- a/groups/bsl/bslim/bslim_printer.cpp
+++ b/groups/bsl/bslim/bslim_printer.cpp
@@ -168,7 +168,7 @@ void Printer_Helper::printRaw(bsl::ostream&                  stream,
     if (bsl::isprint(data)) {
         // print within quotes
 
-        stream << "'" << data <<"'";
+        stream << "'" << data << "'";
     }
     else {
         switch(data) {
@@ -242,6 +242,23 @@ void Printer_Helper::printRaw(bsl::ostream&              stream,
                << bsl::showbase
                << reinterpret_cast<bsls::Types::UintPtr>(data);
     }
+    if (spacesPerLevel >= 0) {
+        stream << '\n';
+    }
+}
+
+void Printer_Helper::printRaw(bsl::ostream&              stream,
+                              const bslstl::StringRef&   data,
+                              int                        ,
+                              int                        spacesPerLevel,
+                              bslmf::SelectTraitCase<>)
+{
+    // Use the defined 'operator<<' for 'bslstl::StringRef' because it does
+    // not define a 'print' method and also does not define the
+    // 'bslalg::HasStlIterators' type trait due to only having defined a
+    // 'const_iterator' interface.
+
+    stream << '"' << data << '"';
     if (spacesPerLevel >= 0) {
         stream << '\n';
     }

--- a/groups/bsl/bslim/bslim_printer.h
+++ b/groups/bsl/bslim/bslim_printer.h
@@ -662,6 +662,9 @@ class Printer {
         //: o If 'TYPE' is a 'bsl::pair' object, print out the two elements of
         //:   the pair.
         //:
+        //: o If 'TYPE' is a 'bslstl::StringRef' object, print the referenced
+        //:   string enclosed in quotes (possibly including embedded 0s).
+        //:
         //: o If 'TYPE' has STL iterators (this includes all STL sequence and
         //:   associative containers: vector, deque, list, set, map, multiset,
         //:   multimap, unordered_set, unordered_map, unordered_multiset, and
@@ -752,6 +755,9 @@ class Printer {
         //:
         //: o If 'TYPE' is a 'bsl::pair' object, print out the two elements of
         //:   the pair.
+        //:
+        //: o If 'TYPE' is a 'bslstl::StringRef' object, print the referenced
+        //:   string enclosed in quotes (possibly including embedded 0s).
         //:
         //: o If 'TYPE' has STL iterators (this includes all STL sequence and
         //:   associative containers: vector, deque, list, set, map, multiset,
@@ -921,6 +927,13 @@ struct Printer_Helper {
     static void printRaw(
                         bsl::ostream&              stream,
                         const bsl::pair<T1, T2>&   data,
+                        int                        level,
+                        int                        spacesPerLevel,
+                        bslmf::SelectTraitCase<>);
+
+    static void printRaw(
+                        bsl::ostream&              stream,
+                        const bslstl::StringRef&   data,
                         int                        level,
                         int                        spacesPerLevel,
                         bslmf::SelectTraitCase<>);

--- a/groups/bsl/bslim/bslim_printer.t.cpp
+++ b/groups/bsl/bslim/bslim_printer.t.cpp
@@ -839,15 +839,18 @@ int main(int argc, char *argv[])
         // --------------------------------------------------------------------
         // 'printValue' ALL STL SEQUENCE AND ASSOCIATIVE CONTAINERS
         //
-        // Concern:
-        //   Though 'bslim' has no awareness of STL types, it knows about pairs
-        //   and can print ranges, which should enable it to print these types.
-        //   Verify that this is the case.
+        // Concerns:
+        //: 1 Printing a type defining 'bslalg::HasStlIterators' (i.e., STL
+        //:   container types) will print each of the elements in the range
+        //:   between 'begin' and 'end'.
+        //: 2 Printing a 'bsl::pair' will print the first and second element of
+        //:   the pair.
+        //: 3 Printing a 'bslstl::StringRef' will print the referenced string.
         //
         // Plan:
-        //   Create and populate various 'bsl' objects, print using range
-        //   'printValue', and verify that the string printed out is what is
-        //   expected.
+        //: 1 Create and populate various 'bsl' objects, print using range
+        //:   'printValue', and verify that the string printed out is what is
+        //:   expected.
         // --------------------------------------------------------------------
 
         if (verbose) cout << endl <<
@@ -1031,7 +1034,7 @@ int main(int argc, char *argv[])
             const bsl::multimap<int, int>& MM = mm;
             for (int i = 0; i < NUM_DATA; ++i) {
                 const S& s = redundantData[i];
-                mm.insert(std::pair<int, int>(s.d_key, s.d_value));
+                mm.insert(bsl::pair<int, int>(s.d_key, s.d_value));
             }
             bsl::ostringstream out;
             bslim::Printer p(&out, 2, 2);
@@ -1147,7 +1150,7 @@ int main(int argc, char *argv[])
             const bsl::unordered_multimap<int, int>& MM = mm;
             for (int i = 0; i < NUM_DATA; ++i) {
                 const S& s = redundantData[i];
-                mm.insert(std::pair<int, int>(s.d_key, s.d_value));
+                mm.insert(bsl::pair<int, int>(s.d_key, s.d_value));
             }
             bsl::ostringstream out;
             bslim::Printer p(&out, 2, 2);
@@ -1167,6 +1170,32 @@ int main(int argc, char *argv[])
                 }
                 EXP << "      ]\n";
             }
+
+            LOOP2_ASSERT(EXP.str(), out.str(), EXP.str() == out.str());
+        }
+
+        {
+            bslstl::StringRef ref = "Testing";
+            const bslstl::StringRef& REF = ref;
+            bsl::ostringstream out;
+            bslim::Printer p(&out, 2, 2);
+            p.printAttribute("stringref", REF);
+
+            bsl::ostringstream EXP;
+            EXP << "      stringref = \"Testing\"\n";
+
+            LOOP2_ASSERT(EXP.str(), out.str(), EXP.str() == out.str());
+        }
+
+        {
+            bslstl::StringRef ref = "Testing";
+            const bslstl::StringRef& REF = ref;
+            bsl::ostringstream out;
+            bslim::Printer p(&out, 0, -1);
+            p.printAttribute("stringref", REF);
+
+            bsl::ostringstream EXP;
+            EXP << " stringref = \"Testing\"";
 
             LOOP2_ASSERT(EXP.str(), out.str(), EXP.str() == out.str());
         }


### PR DESCRIPTION
Printing `bslstl::StringRef` values was not previously supported
because the type does not contain a `print()` method and also does
not declare the `bslalg::HasStlIterators` type trait due to not
fulfilling the requirements.  Since `StringRef` values should print
enclosed in quotes similar to `bsl::string` values, support printing
them directly and defer to `StringRef`'s `operator<<` implementation.
