### PR TITLE
bdlt_datetime: Remove trailing enum comma.

### DIFF
--- a/groups/bdl/bdlt/bdlt_datetime.h
+++ b/groups/bdl/bdlt/bdlt_datetime.h
@@ -293,7 +293,7 @@ class Datetime {
         k_MILLISECONDS_PER_DAY    = TimeUnitRatio::k_MS_PER_D_32,
         k_MILLISECONDS_PER_HOUR   = TimeUnitRatio::k_MS_PER_H_32,
         k_MILLISECONDS_PER_MINUTE = TimeUnitRatio::k_MS_PER_M_32,
-        k_MILLISECONDS_PER_SECOND = TimeUnitRatio::k_MS_PER_S_32,
+        k_MILLISECONDS_PER_SECOND = TimeUnitRatio::k_MS_PER_S_32
     };
 
     // CLASS DATA


### PR DESCRIPTION
The trailing comma causes a compiler warning when using Oracle CC:

```
bdlt_datetime.h, line 297: Warning: Identifier expected instead of "}".
1 Warning(s) detected.
```
