### PR TITLE
build: Fix Solaris application of linker flag -lrt in bsl.

### DIFF
--- a/groups/bsl/group/bsl.defs
+++ b/groups/bsl/group/bsl.defs
@@ -34,12 +34,6 @@ unix-*-*-*-*    	_       STL_DEFINES     = $(STL_EXCDEFS)
 !! unix-*-*-*-* 	mt      STL_MTDEFS      =
 unix-*-*-*-*    	_       STL_DEFINES     = $(STL_MTDEFS)
 
-# STL_NATIVE* defines explicit locations of native STL, used in packages that
-# are beneath bsl+stlport until their test drivers no longer use iostreams;
-# set STL_INCLUDE to STL_NATIVEINC and STL_LDFLAGS to STL_NATIVELIB
-unix-dgux		_	STL_NATIVEINC	= -I/usr/local/como/libcomo
-unix-dgux		_	STL_NATIVELIB   = -L/usr/local/como/libcomo -lcomo
-
 unix-SunOS-*-*-*	_	STL_CXXFLAGS	= -library=no%rwtools7
 !! unix-SunOS-*-*-gcc	_	STL_CXXFLAGS	=
 
@@ -56,12 +50,7 @@ unix-SunOS-*-*-*	_	STL_CXXFLAGS	= -library=no%rwtools7
 unix-AIX-*-*-*  	_	BDE_LDFLAGS	= $(BSL_INCLUDES)
 
 # -lrt needed by bsls_systemtime.cpp
-unix-SunOS-*-*-*        _       BDE_ENDLDFLAGS  = -lrt
-
-# on Sun and Forte6 we need sunmath
-
-unix-SunOS-*-*-cc-5.2 	_ 	BDE_EXTRALIBS = -lsunmath
-!! unix-SunOS-*-*-cc-5.5  _	BDE_EXTRALIBS =
+unix-SunOS-*-*-*        _       BDE_ENDLDFLAGS  = $(BDE_DYNAMIC) -lrt $(BDE_STATIC)
 
 -- *			_	BDE_ENDLDFLAGS = $(BSL_EXTRALIBS)
 


### PR DESCRIPTION
Previously, `-lrt` was added to `BDE_ENDLDFLAGS` in `bsl.defs` without
being enclosed by `$(BDE_DYNAMIC)` and `$(BDE_STATIC)` flags.  This
causes the linker to fail because a static `librt` does not exist.

```
[bsls_alignedbuffer.t.cpp.79.o (ERROR)] <<<<<<<<<<
ld: fatal: library -lrt: not found
ld: fatal: file processing errors. No output written to bde/build/groups/bsl/bsls/bsls_alignedbuffer.t
>>>>>>>>>>
```

Unneeded flags in `bsl.defs` for DG-UX and the old Solaris Forte6
compiler are removed.

Tested that full build of all code and test drivers works on Solaris with these changes.
