### PR TITLE
bdl+decnumber: Work around Clang bug handling GNU inlines.

### DIFF
--- a/groups/bdl/bdl+decnumber/package/bdl+decnumber.opts
+++ b/groups/bdl/bdl+decnumber/package/bdl+decnumber.opts
@@ -2,6 +2,14 @@
 
 *        _    DEF_CFLAGS   = -I$(BDL_DECNUMBER_LOCN)/common -I$(BDL_DECNUMBER_LOCN)/
 
+# Clang fix for building C files due to Clang bug when handling GNU C89 style
+# inlines in C99 mode (default).  The inlines are mis-handled and wind up
+# causing duplicate symbols that causing the link to fail.  This bug is
+# documented here: http://llvm.org/bugs/show_bug.cgi?id=5960
+
+!!  unix-*-*-*-gcc-clang    _   USER_CFLAGS   = -std=gnu89
+!!  unix-*-*-*-clang        _   USER_CFLAGS   = -std=gnu89
+
 # Install the following header files.
 
 *        _    INSTALL_INC  = decContext.h  decDouble.h  decNumberLocal.h  decQuad.h  decSingle.h


### PR DESCRIPTION
The C files in `bdl+decnumber` must be built in `-std=gnu89` mode with
Clang to work around a Clang bug when handling GNU-style C89 inlines
in C99 compilation mode.  This bug is documented in the upstream LLVM
bug-tracker here: http://llvm.org/bugs/show_bug.cgi?id=5960

Without this fix, `bdl+decnumber` test driver links would fail in this manner when building with Clang on Linux:

```
[bdldfp_denselypackeddecimalimputil.t.cpp.359.o (ERROR)] <<<<<<<<<<
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decQuad.c.367.o): In function `gnu_dev_major':
../groups/bdl/bdl+decnumber/decQuad.c:(.text+0x0): multiple definition of `gnu_dev_major'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x0): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decQuad.c.367.o): In function `gnu_dev_makedev':
../groups/bdl/bdl+decnumber/decQuad.c:(.text+0x70): multiple definition of `gnu_dev_makedev'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x70): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decQuad.c.367.o): In function `gnu_dev_minor':
../groups/bdl/bdl+decnumber/decQuad.c:(.text+0x40): multiple definition of `gnu_dev_minor'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x40): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decSingle.c.367.o): In function `gnu_dev_major':
../groups/bdl/bdl+decnumber/decSingle.c:(.text+0x0): multiple definition of `gnu_dev_major'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x0): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decSingle.c.367.o): In function `gnu_dev_makedev':
../groups/bdl/bdl+decnumber/decSingle.c:(.text+0x70): multiple definition of `gnu_dev_makedev'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x70): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decSingle.c.367.o): In function `gnu_dev_minor':
../groups/bdl/bdl+decnumber/decSingle.c:(.text+0x40): multiple definition of `gnu_dev_minor'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x40): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decContext.c.367.o): In function `gnu_dev_major':
../groups/bdl/bdl+decnumber/decContext.c:(.text+0x0): multiple definition of `gnu_dev_major'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x0): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decContext.c.367.o): In function `gnu_dev_makedev':
../groups/bdl/bdl+decnumber/decContext.c:(.text+0x70): multiple definition of `gnu_dev_makedev'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x70): first defined here
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decContext.c.367.o): In function `gnu_dev_minor':
../groups/bdl/bdl+decnumber/decContext.c:(.text+0x40): multiple definition of `gnu_dev_minor'
groups/bdl/bdl+decnumber/libbdl+decnumber.a(decDouble.c.367.o):../groups/bdl/bdl+decnumber/decDouble.c:(.text+0x40): first defined here
clang-3.4: error: linker command failed with exit code 1 (use -v to see invocation)
>>>>>>>>>>
```

Signed-off-by: Andrew Paprocki <andrew@ishiboo.com>