### PR TITLE
Include native unordered_map/set in dual STL mode

### DIFF
--- a/groups/bsl/bsl+stdhdrs/unordered_map
+++ b/groups/bsl/bsl+stdhdrs/unordered_map
@@ -29,13 +29,11 @@ BSLS_IDENT("$Id: $")
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
-#if 0 // Native STL header disabled until we routinely test for C++11 *libs*
 #   if defined(BSLS_COMPILERFEATURES_SUPPORT_INCLUDE_NEXT)
 #     include_next <unordered_map>
 #   else
 #     include BSL_NATIVE_CPP_LIB_HEADER(unordered_map)
 #   endif
-#endif
 
 #else // defined(BSL_OVERRIDES_STD)
 

--- a/groups/bsl/bsl+stdhdrs/unordered_map.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/unordered_map.SUNWCCh
@@ -25,9 +25,7 @@ BSLS_IDENT("$Id: $")
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
-#if 0 // Native STL header disabled until we routinely test for C++11 *libs*
 #   include BSL_NATIVE_CPP_LIB_HEADER(unordered_map)
-#endif
 
 #else
 

--- a/groups/bsl/bsl+stdhdrs/unordered_set
+++ b/groups/bsl/bsl+stdhdrs/unordered_set
@@ -29,13 +29,11 @@ BSLS_IDENT("$Id: $")
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
-#if 0 // Native STL header disabled until we routinely test for C++11 *libs*
 #   if defined(BSLS_COMPILERFEATURES_SUPPORT_INCLUDE_NEXT)
 #     include_next <unordered_set>
 #   else
 #     include BSL_NATIVE_CPP_LIB_HEADER(unordered_set)
 #   endif
-#endif
 
 #else // defined(BSL_OVERRIDES_STD)
 

--- a/groups/bsl/bsl+stdhdrs/unordered_set.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/unordered_set.SUNWCCh
@@ -25,9 +25,7 @@ BSLS_IDENT("$Id: $")
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
-#if 0 // Native STL header disabled until we routinely test for C++11 *libs*
 #   include BSL_NATIVE_CPP_LIB_HEADER(unordered_set)
-#endif
 
 #else
 


### PR DESCRIPTION
This commit fixes #150.  When BSL_OVERRIDES_STD is not defined, attempt
to include the native version of unordered_map/set.  This is required to
avoid changing behaviour: if a file including unordered_map compiled
before BDE was installed and used, it will continue to work afterwards,
and if a file failed to compile before, it will continue to fail also.