### PR TITLE
gcc/clang BSLS_PERFORMANCEHINT_UNLIKELY_HINT impl

### DIFF
--- a/groups/bsl/bsls/bsls_performancehint.h
+++ b/groups/bsl/bsls/bsls_performancehint.h
@@ -401,6 +401,11 @@ namespace BloombergLP {
 #elif defined(BDE_BUILD_TARGET_OPT) && defined(BSLS_PLATFORM_CMP_IBM)
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
                              BloombergLP::bsls::PerformanceHint::lowFrequency()
+#elif defined(BDE_BUILD_TARGET_OPT) \
+   && ((defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
+       ||(defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold)))
+    #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
+                             BloombergLP::bsls::PerformanceHint::lowFrequency()
 #else
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT
 #endif
@@ -450,6 +455,10 @@ struct PerformanceHint {
 #endif  // BSLS_PLATFORM_CMP_SUN
 #endif  // BDE_BUILD_TARGET_OPT
 
+#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
+ || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold))
+    __attribute__((__cold__))
+#endif
     static void lowFrequency();
         // This is an empty function that is marked with low execution
         // frequency using pragmas.  If this function is placed in a block of
@@ -530,7 +539,12 @@ void PerformanceHint::prefetchForWriting(void *address)
 }
 
 // This function must be inlined for the pragma to take effect on the branch
-// prediction.
+// prediction in IBM xlC.
+
+#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
+ || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold))
+__attribute__((__cold__))
+#endif
 inline
 void PerformanceHint::lowFrequency()
 {

--- a/groups/bsl/bsls/bsls_performancehint.h
+++ b/groups/bsl/bsls/bsls_performancehint.h
@@ -395,17 +395,28 @@ namespace BloombergLP {
 
 #endif
 
+#if defined(BSLS_PLATFORM_CMP_CLANG)
+    #if __has_attribute(cold)
+    #define BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD  __attribute__((cold))
+    #endif
+#elif (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300)
+    #define BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD  __attribute__((cold))
+#endif
+
 #if defined(BDE_BUILD_TARGET_OPT) && defined(BSLS_PLATFORM_CMP_SUN)
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
                              BloombergLP::bsls::PerformanceHint::rarelyCalled()
 #elif defined(BDE_BUILD_TARGET_OPT) && (                                      \
-      defined(BSLS_PLATFORM_CMP_IBM)                                          \
-   || (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300)  \
-   || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold)))
+      (defined(BSLS_PLATFORM_CMP_IBM)                                         \
+       || defined(BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD)))
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
                              BloombergLP::bsls::PerformanceHint::lowFrequency()
 #else
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT
+#endif
+
+#ifndef BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD
+#define BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD
 #endif
 
 namespace bsls {
@@ -453,10 +464,7 @@ struct PerformanceHint {
 #endif  // BSLS_PLATFORM_CMP_SUN
 #endif  // BDE_BUILD_TARGET_OPT
 
-#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300)    \
- || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold))
-    __attribute__((__cold__))
-#endif
+    BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD
     static void lowFrequency();
         // This is an empty function that is marked with low execution
         // frequency using pragmas.  If this function is placed in a block of
@@ -539,10 +547,7 @@ void PerformanceHint::prefetchForWriting(void *address)
 // This function must be inlined for the pragma to take effect on the branch
 // prediction in IBM xlC.
 
-#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
- || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold))
-__attribute__((__cold__))
-#endif
+BSLS_PERFORMANCEHINT_FUNC_ATTRIBUTE_COLD
 inline
 void PerformanceHint::lowFrequency()
 {

--- a/groups/bsl/bsls/bsls_performancehint.h
+++ b/groups/bsl/bsls/bsls_performancehint.h
@@ -378,7 +378,7 @@ namespace BloombergLP {
 // that support '__builtin_expect'.
 
 #if defined(BDE_BUILD_TARGET_OPT) &&                                          \
-   (defined(BSLS_PLATFORM_CMP_GNU) ||                                        \
+   (defined(BSLS_PLATFORM_CMP_GNU) ||                                         \
    (defined(BSLS_PLATFORM_CMP_IBM) && BSLS_PLATFORM_CMP_VER_MAJOR >= 0x0900))
 
     #define BSLS_PERFORMANCEHINT_PREDICT_LIKELY(expr)                         \
@@ -398,12 +398,10 @@ namespace BloombergLP {
 #if defined(BDE_BUILD_TARGET_OPT) && defined(BSLS_PLATFORM_CMP_SUN)
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
                              BloombergLP::bsls::PerformanceHint::rarelyCalled()
-#elif defined(BDE_BUILD_TARGET_OPT) && defined(BSLS_PLATFORM_CMP_IBM)
-    #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
-                             BloombergLP::bsls::PerformanceHint::lowFrequency()
-#elif defined(BDE_BUILD_TARGET_OPT) \
-   && ((defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
-       ||(defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold)))
+#elif defined(BDE_BUILD_TARGET_OPT) && (                                      \
+      defined(BSLS_PLATFORM_CMP_IBM)                                          \
+   || (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300)  \
+   || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold)))
     #define BSLS_PERFORMANCEHINT_UNLIKELY_HINT                                \
                              BloombergLP::bsls::PerformanceHint::lowFrequency()
 #else
@@ -455,7 +453,7 @@ struct PerformanceHint {
 #endif  // BSLS_PLATFORM_CMP_SUN
 #endif  // BDE_BUILD_TARGET_OPT
 
-#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300) \
+#if (defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40300)    \
  || (defined(BSLS_PLATFORM_CMP_CLANG) && __has_attribute(cold))
     __attribute__((__cold__))
 #endif

--- a/groups/bsl/bsls/bsls_performancehint.t.cpp
+++ b/groups/bsl/bsls/bsls_performancehint.t.cpp
@@ -112,7 +112,8 @@ const int TESTSIZE = 10;
 const int TESTSIZE = 100;
 #endif
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && !defined(BSLS_PLATFORM_CMP_CLANG)
+#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40600      \
+ && !defined(BSLS_PLATFORM_CMP_CLANG)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wlarger-than="
 #endif
@@ -123,7 +124,8 @@ volatile int array2[SIZE]; // for 'addWithPrefetch'
 volatile int array3[SIZE]; // for 'addWithoutPrefetch
 volatile int array4[SIZE]; // for 'addWithoutPrefetch
 
-#if defined(BSLS_PLATFORM_CMP_GNU) && !defined(BSLS_PLATFORM_CMP_CLANG)
+#if defined(BSLS_PLATFORM_CMP_GNU) && BSLS_PLATFORM_CMP_VERSION >= 40600      \
+ && !defined(BSLS_PLATFORM_CMP_CLANG)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
implement BSLS_PERFORMANCEHINT_UNLIKELY_HINT for gcc and clang when the
compilers support __attribute__(cold)