### PR TITLE
Expand support for ARM cpus in bsls_platform.h

### DIFF
--- a/groups/bsl/bsls/bsls_platform.h
+++ b/groups/bsl/bsls/bsls_platform.h
@@ -590,7 +590,17 @@ struct bsls_Platform_Assert;
         #endif
     #elif defined(__arm__)
         #define BSLS_PLATFORM_CPU_ARM 1
-        #if defined(__ARM_ARCH_5T__)        \
+        #if defined(__ARM_ARCH)
+            #if __ARM_ARCH == 6
+                #define BSLS_PLATFORM_CPU_ARM_V6
+            #elif __ARM_ARCH == 7
+                #define BSLS_PLATFORM_CPU_ARM_V7
+            #elif __ARM_ARCH == 8
+                #define BSLS_PLATFORM_CPU_ARM_V8
+            #elif __ARM_ARCH == 9
+                #define BSLS_PLATFORM_CPU_ARM_V9
+            #endif
+        #elif defined(__ARM_ARCH_5T__)        \
             || defined(__ARM_ARCH_5TE__)    \
             || defined(__ARM_ARCH_5TEJ__)
             #define BSLS_PLATFORM_CPU_ARM_V5


### PR DESCRIPTION
Later ARM models supported by GCC and Clang allow for a more unified
system of specifying which model and features are supported.  This
also comes with a unified model-detection mechanism.  This updated
mechanism is now (partially) supported by bsls_platform in its
platform query and macro section.