### PR TITLE
bslstl::StringRef: always call width(0) in op<<

### DIFF
--- a/groups/bsl/bslstl/bslstl_stringref.h
+++ b/groups/bsl/bslstl/bslstl_stringref.h
@@ -1379,8 +1379,9 @@ bslstl::operator<<(std::basic_ostream<CHAR_TYPE>& stream,
     }
     else {
         stringRef.write(stream);
-        stream.width(0);
     }
+
+    stream.width(0);
 
     return stream;
 }


### PR DESCRIPTION
Correct `bslstl::StringRef`'s `operator<<` to always call `stream.width(0)`, in line with the behavior of `bsl::string`'s `operator<<`.

This fixes the output of the following code:

    bsl::cout << bsl::setw(8) << bslstl::StringRef("12")
                              << "34"
              << "\n";

which prior to this commit would ouput:

    "      12      34"

After this commit, it ouputs:

    "      1234"

which is the same output if the `12` were printed as either a `const char*` or a `bsl::string`, rather than a `bslstl::StringRef`.