### PR TITLE
Remove cycles from bslmt (mostly bdl in test drivers)

### DIFF
--- a/groups/bsl/bslmt/bslmt_barrier.t.cpp
+++ b/groups/bsl/bslmt/bslmt_barrier.t.cpp
@@ -22,10 +22,6 @@
 #include <bsls_systemtime.h>
 #include <bsls_timeutil.h>
 
-/* TBD -- bind
-#include <bdlf_bind.h>
-*/
-
 #include <bsl_algorithm.h>
 #include <bsl_functional.h>
 #include <bsl_limits.h>
@@ -656,14 +652,11 @@ public:
       detached.setDetachedState(
                                bslmt::ThreadAttributes::e_CREATE_DETACHED);
 
-      /* TBD -- bind
-      ASSERT(0 == bslmt::ThreadUtil::create(&dummy, detached,
-                           bdlf::BindUtil::bind(&Case7_Waiter::run,
-                                               this)));
-      */
+
+      ASSERT(0 == bslmt::ThreadUtil::create(&dummy, detached, *this));
    }
 
-   void run() {
+   void operator()() {
       ASSERT(0 != d_state);
       for (int i = 0; i < d_numWaits; ++i) {
          d_barrier->wait();
@@ -806,9 +799,7 @@ int main(int argc, char *argv[])
        if (veryVerbose) {
           cout << "   ...Basic barrier..." << endl;
        }
-       /* TBD -- bind
        case7(&basicBarrier, veryVerbose, k_NUM_THREADS, k_NUM_SHORT_WAITS);
-       */
 
       } break;
 

--- a/groups/bsl/bslmt/bslmt_once.h
+++ b/groups/bsl/bslmt/bslmt_once.h
@@ -138,41 +138,48 @@ BSLS_IDENT("$Id: $")
 ///Second Implementation
 ///- - - - - - - - - - -
 // The next singleton function implementation directly uses the 'doOnce' method
-// of 'bslmt::Once'.  We begin by declaring a simple function that does most of
+// of 'bslmt::Once'.  We begin by declaring a functor type that does most of
 // the work of the singleton, i.e., constructing the string and setting a
 // (static) pointer to the string:
 //..
 //  static bsl::string *theSingletonPtr = 0;
 //
-//  void singletonImp(const char *s)
-//  {
-//      static bsl::string theSingleton(s);
-//      theSingletonPtr = &theSingleton;
-//  }
-//..
-// The above function is *not* thread-safe.  Firstly, many threads might
-// attempt to simultaneously construct the 'theSingleton' object.  Secondly,
-// once 'theSingletonPtr' is set by one thread, other threads still might not
-// see the change (and try to initialize the singleton again).
+//  class SingletonInitializer {
+//      const char *d_initialValue;
 //
-// The 'singleton1' function, below, calls 'singletonImp' via the 'callOnce'
-// method of 'bslmt::Once' to ensure that 'singletonImp' is called by only one
-// thread and that the result is visible to all threads.  We start by creating
-// and initializing a static object of type 'bslmt::Once':
-//..
-//  #include <bdlf_bind.h>
+//    public:
+//      SingletonInitializer(const char *initialValue)
+//      : d_initialValue(initialValue)
+//      {
+//      }
 //
+//      void operator()() const {
+//         static bsl::string theSingleton(d_initialValue);
+//         theSingletonPtr = &theSingleton;
+//      }
+//  };
+//..
+// The function call operator of the type above is *not* thread-safe.  Firstly,
+// many threads might attempt to simultaneously construct the 'theSingleton'
+// object.  Secondly, once 'theSingletonPtr' is set by one thread, other
+// threads still might not see the change (and try to initialize the singleton
+// again).
+//
+// The 'singleton1' function, below, invokes 'SingletonInitializer::operator()'
+// via the 'callOnce' method of 'bslmt::Once' to ensure that 'operator()' is
+// called by only one thread and that the result is visible to all threads.  We
+// start by creating and initializing a static object of type 'bslmt::Once':
+//..
 //  const bsl::string& singleton1(const char *s)
 //  {
 //      static bslmt::Once once = BSLMT_ONCE_INITIALIZER;
 //..
-// Since the 'callOnce' method takes only a no-argument functor (or function),
-// to call 'callOnce', we must bind our argument 's' to our function,
-// 'singletonImp' using a binder method and then pass that functor to
-// 'callOnce'.  The first thread (and only the first thread) entering this
-// section of code we will set 'theSingleton'.
+// We construct a 'SingletonInitializer' instance, effectively "binding" the
+// argument 's' so that it may be used in a function invoked by 'callOnce',
+// which takes only a no-argument functor (or function).  The first thread (and
+// only the first thread) entering this section of code will set 'theSingleton'.
 //..
-//      once.callOnce(bdlf::BindUtil::bind(singletonImp, s));
+//      once.callOnce(SingletonInitializer(s));
 //      return *theSingletonPtr;
 //  }
 //..
@@ -200,10 +207,11 @@ BSLS_IDENT("$Id: $")
 /// - - - - - - - - - -
 // Our next implementation, 'singleton2', eliminates the need for the
 // 'singletonImp' function and thereby does away with the use of the
-// 'bdlf::BindUtil' method; however, it does require use of
-// 'bslmt::Once::OnceLock', created on each thread's stack and passed to the
-// methods of 'bslmt::Once'.  First, we declare a static 'bslmt::Once' object
-// as before, and also declare a static pointer to 'bsl::string':
+// a functor type to "bind" the initialization parameter; however, it does
+// require use of 'bslmt::Once::OnceLock', created on each thread's stack and
+// passed to the methods of 'bslmt::Once'.  First, we declare a static
+// 'bslmt::Once' object as before, and also declare a static pointer to
+// 'bsl::string':
 //..
 //  const bsl::string& singleton2(const char *s)
 //  {

--- a/groups/bsl/bslmt/bslmt_semaphore.t.cpp
+++ b/groups/bsl/bslmt/bslmt_semaphore.t.cpp
@@ -15,9 +15,6 @@
 #include <bslim_testutil.h>
 
 #include <bsls_timeinterval.h>
-/* TBD -- bind
-#include <bdlf_bind.h>
-*/
 #include <bsls_atomic.h>
 #include <bsl_iostream.h>
 #include <bsl_cstdlib.h>
@@ -164,11 +161,24 @@ void aSsErT(bool condition, const char *message, int line)
 
 typedef bslmt::Semaphore Obj;
 
-void waitAndSet(bslmt::Semaphore *obj, bsls::AtomicInt *val)
-{
-    obj->wait();
-    (*val) = 1;
-}
+class WaitAndSetJob {
+
+    bslmt::Semaphore *d_obj;
+    bsls::AtomicInt *d_val;
+
+  public:
+    WaitAndSetJob(bslmt::Semaphore *obj,
+                  bsls::AtomicInt *val)
+    : d_obj(obj)
+    , d_val(val)
+    {
+    }
+
+    void operator()() const {
+        d_obj->wait();
+        (*d_val) = 1;
+    }
+};
 
 // ============================================================================
 //                               MAIN PROGRAM
@@ -205,18 +215,16 @@ int main(int argc, char *argv[])
                  << "=============" << endl;
         }
         {
-            /* TBD -- bind
             Obj X;
             bslmt::ThreadUtil::Handle h;
             bsls::AtomicInt flag;
-            ASSERT(0 == bslmt::ThreadUtil::create(
-                            &h, bdlf::BindUtil::bind(&waitAndSet, &X, &flag)));
+            ASSERT(0 == bslmt::ThreadUtil::create(&h,
+                                                  WaitAndSetJob(&X, &flag)));
             bslmt::ThreadUtil::sleep(bsls::TimeInterval(1));
             ASSERT(0 == flag);
             X.post();
             bslmt::ThreadUtil::join(h);
             ASSERT(1 == flag);
-            */
         }
       } break;
       case 1: {

--- a/groups/bsl/bslmt/bslmt_threadattributes.t.cpp
+++ b/groups/bsl/bslmt/bslmt_threadattributes.t.cpp
@@ -9,7 +9,6 @@
 
 #include <bslmt_threadattributes.h>
 
-#include <bslmt_configuration.h>
 #include <bslmt_platform.h>
 
 #include <bslim_testutil.h>
@@ -140,10 +139,17 @@ void aSsErT(bool condition, const char *message, int line)
         int handle;
         myThreadCreate(&handle, attributes, &myThreadFunction);
     }
-//..
 // Finally, we define the thread creation function, and show how a thread
-// attributes object might be interpreted by it:
+// attributes object might be interpreted by it. This creation function
+// supplies its own default values for stack and thread guard sizes; a real
+// routine using 'ThreadAttributes' should base its defaults on the
+// 'bslmt_configuration' component.
 //..
+    enum {
+       MY_DEFAULT_STACK_SIZE = 512 * 1024,
+       MY_DEFAULT_GUARD_SIZE = 16384
+    };
+
     void myThreadCreate(int                             *threadHandle,
                         const bslmt::ThreadAttributes&   attributes,
                         void                           (*function)())
@@ -153,7 +159,7 @@ void aSsErT(bool condition, const char *message, int line)
     {
         int stackSize = attributes.stackSize();
         if (bslmt::ThreadAttributes::e_UNSET_STACK_SIZE == stackSize) {
-            stackSize = bslmt::Configuration::defaultThreadStackSize();
+            stackSize = MY_DEFAULT_STACK_SIZE;
         }
 
         // Add a "fudge factor" to 'stackSize' to ensure that the client can
@@ -171,7 +177,7 @@ void aSsErT(bool condition, const char *message, int line)
 
         int guardSize = attributes.guardSize();
         if (bslmt::ThreadAttributes::e_UNSET_GUARD_SIZE == guardSize) {
-            guardSize = bslmt::Configuration::nativeDefaultThreadGuardSize();
+            guardSize = MY_DEFAULT_GUARD_SIZE;
         }
 
         int policy = attributes.schedulingPolicy();


### PR DESCRIPTION
Removed cycles from bslmt.  (1) Removed bslmt_configuration from the usage example of bslmt_threadattributes, replaced with hardcoded defaults and a comment. (2) Removed the use of bdlc::Queue from the TimedSemaphore usage example, and reworked the example to use timedWait as per the "tbd" there. (3) Removed a variety of uses of 'bdlf::Bind' from test drivers using special-purpose functor types.