### PR TITLE
bslma: Update `ManagedPtr` constructor docs.

### DIFF
--- a/groups/bsl/bslma/bslma_managedptr.h
+++ b/groups/bsl/bslma/bslma_managedptr.h
@@ -976,10 +976,10 @@ class ManagedPtr {
         // constructor will not compile unless 'MANAGED_TYPE *' is convertible
         // to 'TARGET_TYPE *'.  The behavior is undefined unless the managed
         // object (if any) can be destroyed by the specified 'factory', or if
-        // the the lifetime of the managed object is already managed by another
-        // object.  Note that 'bslma::Allocator', and any class publicly and
-        // unambiguously derived from 'bslma::Allocator', meets the
-        // requirements for 'FACTORY_TYPE'.
+        // '0 == factory && 0 != ptr', or if the the lifetime of the managed
+        // object is already managed by another object.  Note that
+        // 'bslma::Allocator', and any class publicly and unambiguously derived
+        // from 'bslma::Allocator', meets the requirements for 'FACTORY_TYPE'.
 
     template <class FACTORY_TYPE>
     ManagedPtr(bsl::nullptr_t, FACTORY_TYPE *factory);


### PR DESCRIPTION
The overload of `load()` that takes a `FACTORY_TYPE` correctly states
the undefined behavior if `0 == factory && 0 != ptr`, but the
corresponding constructor does not.  Added this to the list of
undefined behavior to prevent confusion.