### PR TITLE
Using stronger cast in dumpData.

### DIFF
--- a/groups/bsl/bslstl/bslstl_allocatortraits.t.cpp
+++ b/groups/bsl/bslstl/bslstl_allocatortraits.t.cpp
@@ -165,7 +165,7 @@ template <class DATA_TYPE>
 void dumpData(const DATA_TYPE& data)
 {
     if (forceDestructorCall) {
-        printf("%p: %c\n", &data, *reinterpret_cast<const char *>(&data));
+        printf("%p: %c\n", &data, *(const char *)(&data));
     }
 }
 


### PR DESCRIPTION
reinterpret_cast will fail here if/when the type is volatile (which it
is in at least one case, which is breaking the build).

To accomplish the same thing using only modern casts is very easy in
C++11, but not easy in classic C++.