### PR TITLE
Use unsigned constants for left bitshift

### DIFF
--- a/groups/bdl/bdlde/bdlde_charconvertutf16.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertutf16.cpp
@@ -365,24 +365,24 @@ struct Utf8 {
         // Masks and shifts used to assemble and dismantle UTF-8 encodings.
 
         ONE_OCT_CONT_WID   = 7,               // Content in a one-octet coding
-        ONE_OCTET_MASK     = 0xff & (~0 << ONE_OCT_CONT_WID),
+        ONE_OCTET_MASK     = 0xff & (~0u << ONE_OCT_CONT_WID),
         ONE_OCTET_TAG      = 0xff & 0,        // Compare this to mask'd bits
 
         CONTINUE_CONT_WID  = 6,               // Content in a continuation
                                               //                      octet
-        CONTINUE_MASK      = 0xff & (~0 << CONTINUE_CONT_WID),
+        CONTINUE_MASK      = 0xff & (~0u << CONTINUE_CONT_WID),
         CONTINUE_TAG       = ONE_OCTET_MASK,  // Compare this to mask'd bits
 
         TWO_OCT_CONT_WID   = 5,               // Content in a two-octet header
-        TWO_OCTET_MASK     = 0xff & (~0 << TWO_OCT_CONT_WID),
+        TWO_OCTET_MASK     = 0xff & (~0u << TWO_OCT_CONT_WID),
         TWO_OCTET_TAG      = CONTINUE_MASK,   // Compare this to mask'd bits
 
         THREE_OCT_CONT_WID = 4,               // Content in a 3-octet header
-        THREE_OCTET_MASK   = 0xff & (~0 << THREE_OCT_CONT_WID),
+        THREE_OCTET_MASK   = 0xff & (~0u << THREE_OCT_CONT_WID),
         THREE_OCTET_TAG    = TWO_OCTET_MASK,  // Compare this to mask'd bits
 
         FOUR_OCT_CONT_WID  = 3,               // Content in a four-octet header
-        FOUR_OCTET_MASK    = 0xff & (~0 << FOUR_OCT_CONT_WID),
+        FOUR_OCTET_MASK    = 0xff & (~0u << FOUR_OCT_CONT_WID),
         FOUR_OCTET_TAG     = THREE_OCTET_MASK // Compare this to mask'd bits
     };
 

--- a/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertutf32.cpp
@@ -140,23 +140,23 @@ enum Utf8Bits {
     // Masks and shifts used to assemble and dismantle UTF-8 encodings.
 
     k_ONE_OCT_CONT_WID   = 7,               // content in a one-octet coding
-    k_ONE_OCTET_MASK     = 0xff & (~0 << k_ONE_OCT_CONT_WID),
+    k_ONE_OCTET_MASK     = 0xff & (~0u << k_ONE_OCT_CONT_WID),
 
     k_CONTINUE_CONT_WID  = 6,               // content in a continuation
                                           //                      octet
-    k_CONTINUE_MASK      = 0xff & (~0 << k_CONTINUE_CONT_WID),
+    k_CONTINUE_MASK      = 0xff & (~0u << k_CONTINUE_CONT_WID),
     k_CONTINUE_TAG       = k_ONE_OCTET_MASK,  // compare this to masked bits
 
     k_TWO_OCT_CONT_WID   = 5,               // content in a two-octet header
-    k_TWO_OCTET_MASK     = 0xff & (~0 << k_TWO_OCT_CONT_WID),
+    k_TWO_OCTET_MASK     = 0xff & (~0u << k_TWO_OCT_CONT_WID),
     k_TWO_OCTET_TAG      = k_CONTINUE_MASK,   // compare this to masked bits
 
     k_THREE_OCT_CONT_WID = 4,               // content in a 3-octet header
-    k_THREE_OCTET_MASK   = 0xff & (~0 << k_THREE_OCT_CONT_WID),
+    k_THREE_OCTET_MASK   = 0xff & (~0u << k_THREE_OCT_CONT_WID),
     k_THREE_OCTET_TAG    = k_TWO_OCTET_MASK,  // compare this to masked bits
 
     k_FOUR_OCT_CONT_WID  = 3,               // content in a four-octet header
-    k_FOUR_OCTET_MASK    = 0xff & (~0 << k_FOUR_OCT_CONT_WID),
+    k_FOUR_OCTET_MASK    = 0xff & (~0u << k_FOUR_OCT_CONT_WID),
     k_FOUR_OCTET_TAG     = k_THREE_OCTET_MASK // compare this to masked bits
 };
 


### PR DESCRIPTION
Left shifting a negative value is undefined behavior. Change the value `~0` to `~0u` to make the literal unsigned.

5.8p2

> The value of E1 << E2 is E1 left-shifted E2 bit positions; vacated bits are zero-filled. If E1 has an unsigned type, the value of the result is E1 × 2E2, reduced modulo one more than the maximum value representable in the result type. Otherwise, if E1 has a signed type and non-negative value, and E1×2E2 is representable in the corresponding unsigned type of the result type, then that value, converted to the result type, is the resulting value; **otherwise, the behavior is undefined.**

This fixes the build with g++ 6