### PR TITLE
Add format function to bdlfp::DecimalUtil

### DIFF
--- a/groups/bdl/bdldfp/bdldfp_decimalutil.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalutil.cpp
@@ -140,6 +140,49 @@ int DecimalUtil::parseDecimal128(Decimal128 *out, const bsl::string& str)
     return parseDecimal128(out, str.c_str());
 }
 
+                                // Formatting functions
+
+void DecimalUtil::format(Decimal32 value, bsl::string *out)
+{
+    char buffer[BDLDFP_DECIMALPLATFORM_SNPRINTF_BUFFER_SIZE];
+
+    DenselyPackedDecimalImpUtil::StorageType32 dpdStorage;
+    dpdStorage = DecimalImpUtil::convertToDPD(*value.data());
+
+    DecimalImpUtil_DecNumber::ValueType32 dpdValue;
+    bsl::memcpy(&dpdValue, &dpdStorage, sizeof(dpdValue));
+
+    DecimalImpUtil_DecNumber::format(dpdValue, buffer);
+    out->assign(buffer);
+}
+
+void DecimalUtil::format(Decimal64 value, bsl::string *out)
+{
+    char buffer[BDLDFP_DECIMALPLATFORM_SNPRINTF_BUFFER_SIZE];
+
+    DenselyPackedDecimalImpUtil::StorageType64 dpdStorage;
+    dpdStorage = DecimalImpUtil::convertToDPD(*value.data());
+
+    DecimalImpUtil_DecNumber::ValueType64 dpdValue;
+    bsl::memcpy(&dpdValue, &dpdStorage, sizeof(dpdValue));
+
+    DecimalImpUtil_DecNumber::format(dpdValue, buffer);
+    out->assign(buffer);
+}
+
+void DecimalUtil::format(Decimal128 value, bsl::string *out)
+{
+    char buffer[BDLDFP_DECIMALPLATFORM_SNPRINTF_BUFFER_SIZE];
+    DenselyPackedDecimalImpUtil::StorageType128 dpdStorage;
+    dpdStorage = DecimalImpUtil::convertToDPD(*value.data());
+
+    DecimalImpUtil_DecNumber::ValueType128 dpdValue;
+    bsl::memcpy(&dpdValue, &dpdStorage, sizeof(dpdValue));
+
+    DecimalImpUtil_DecNumber::format(dpdValue, buffer);
+    out->assign(buffer);
+}
+
                                 // Math functions
 
 Decimal64 DecimalUtil::fma(Decimal64 x, Decimal64 y, Decimal64 z)

--- a/groups/bdl/bdldfp/bdldfp_decimalutil.h
+++ b/groups/bdl/bdldfp/bdldfp_decimalutil.h
@@ -194,6 +194,17 @@ struct DecimalUtil {
         // unspecified if the function returns a non-zero value.
 
 
+                            // Formatting functions
+
+    static void format(Decimal32  value, bsl::string *out);
+    static void format(Decimal64  value, bsl::string *out);
+    static void format(Decimal128 value, bsl::string *out);
+        // Produce a string representation of the specified decimal 'value', in
+        // the specified 'out' string. The string will be suitable for use with
+        // the 'strtod128' function in section 9.6 of the ISO/EIC TR 24732 C
+        // Decimal Floating-Point Technical Report, except that it is
+        // unspecified whether the NaNs returned are quiet or signaling.
+
                                   // math
 
     static Decimal64  fma(Decimal64  x, Decimal64  y, Decimal64  z);

--- a/groups/bdl/bdldfp/bdldfp_decimalutil.t.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalutil.t.cpp
@@ -74,6 +74,13 @@ void aSsErT(bool condition, const char *message, int line)
     }
 }
 
+int                test;
+int             verbose;
+int         veryVerbose;
+int     veryVeryVerbose;
+int veryVeryVeryVerbose;
+static bslma::TestAllocator *pa;
+
 }  // close unnamed namespace
 
 // ============================================================================
@@ -427,13 +434,267 @@ struct NulBuf : bsl::streambuf {
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
 
+
+static void testCase13()
+{
+
+    // ------------------------------------------------------------------------
+    // TESTING format
+    // Concerns: The format functions output human readable strings which
+    //           can be round-tripped using the parse functions.
+    // Plan: Try formatting a variety of different valid values into a string.
+    //       Including minimum and maximum values and special values
+    //       such as 'NaN' and 'Inf'.
+    //       Re-parse the returned string and check that it returns the
+    //       original value.
+    //
+    // Testing:
+    //   void DecimalUtil::format(Decimal32,  bsl::string *out);
+    //   void DecimalUtil::format(Decimal64,  bsl::string *out);
+    //   void DecimalUtil::format(Decimal128, bsl::string *out);
+    // --------------------------------------------------------------------
+    if (verbose) bsl::cout << "\nTESTING FORMAT METHODS"
+                           << "\n=========================="
+                           << bsl::endl;
+
+    typedef BDEC::DecimalUtil Util;
+    {
+#define DEC(X) BDLDFP_DECIMAL_DF(X)
+
+        typedef bdldfp::Decimal32 Type;
+
+        Type INF_P =  bsl::numeric_limits<Type>::infinity();
+        Type INF_N = -bsl::numeric_limits<Type>::infinity();
+        Type NAN_Q =  bsl::numeric_limits<Type>::quiet_NaN();
+        Type NAN_S =  bsl::numeric_limits<Type>::signaling_NaN();
+        Type MAX   = DEC(9.999999e+96);
+        Type MIN   = DEC(-1e-95);
+
+        static const struct {
+            int         d_line;
+            Type        d_decimalValue;
+            const char *d_expected;
+        } DATA[] = {
+            // L      NUMBER               EXPECTED
+            // ---    ---------            --------
+            {  L_,     DEC(0.0),             "0.0" },
+            {  L_,     DEC(1.0),             "1.0" },
+            {  L_,  DEC(9.3E23),         "9.3E+23" },
+            {  L_,    DEC(-1.0),            "-1.0" },
+            {  L_,    DEC(-0.1),            "-0.1" },
+            {  L_,    DEC(4.25),            "4.25" },
+            {  L_,   DEC(-4.25),           "-4.25" },
+            {  L_,          MAX,    "9.999999E+96" },
+            {  L_,          MIN,          "-1E-95" },
+            {  L_,        INF_P,        "Infinity" },
+            {  L_,        INF_N,       "-Infinity" },
+            {  L_,        NAN_Q,             "NaN" },
+            //{  L_,        NAN_S,            "sNaN" },
+        };
+        const int NUM_DATA = sizeof DATA / sizeof *DATA;
+
+        for (int ti = 0; ti < NUM_DATA; ++ti) {
+            const int    LINE       = DATA[ti].d_line;
+            const Type   DECIMAL32  = DATA[ti].d_decimalValue;
+            const char  *EXPECTED   = DATA[ti].d_expected;
+
+            if (veryVerbose) {
+                P_(LINE); P_(EXPECTED); P(DECIMAL32);
+            }
+
+            // Test with Decimal32.
+            {
+                const BDEC::Decimal32 VALUE(DECIMAL32);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+
+                BDEC::Decimal32 INPUT;
+                const int rc = Util::parseDecimal32(&INPUT, ACTUAL);
+
+                ASSERTV(LINE, EXPECTED, rc == 0);
+                if (Util::isNan(VALUE)) {
+                    ASSERTV(LINE, EXPECTED, Util::isNan(INPUT));
+                } else {
+                    ASSERTV(LINE, EXPECTED, INPUT == VALUE);
+                }
+            }
+
+            // Test with Decimal64.
+            {
+                const BDEC::Decimal64 VALUE(DECIMAL32);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+            }
+
+
+            // Test with Decimal128.
+            {
+                const BDEC::Decimal128 VALUE(DECIMAL32);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+            }
+        }
+    }
+    {
+#undef DEC
+#define DEC(lit) BDLDFP_DECIMAL_DD(lit)
+        typedef bdldfp::Decimal64 Type;
+
+        Type INF_P =  bsl::numeric_limits<Type>::infinity();
+        Type INF_N = -bsl::numeric_limits<Type>::infinity();
+        Type NAN_Q =  bsl::numeric_limits<Type>::quiet_NaN();
+        Type NAN_S =  bsl::numeric_limits<Type>::signaling_NaN();
+        Type MAX   =  bdldfp::DecimalImpUtil::parse64(
+                                                     "9.999999999999999e+384");
+        Type MIN   = DEC(1e-383);
+
+        static const struct {
+            int         d_line;
+            Type        d_decimalValue;
+            const char *d_expected;
+        } DATA[] = {
+            // L      NUMBER        EXPECTED
+            // ---    ---------     -------------------------
+            {  L_,     DEC(0.0),                      "0.0" },
+            {  L_,     DEC(1.0),                       "1.0" },
+            {  L_,  DEC(9.3E23),                   "9.3E+23" },
+            {  L_,    DEC(-1.0),                      "-1.0" },
+            {  L_,    DEC(-0.1),                      "-0.1" },
+            {  L_,    DEC(4.25),                      "4.25" },
+            {  L_,   DEC(-4.25),                     "-4.25" },
+            {  L_,          MAX,    "9.999999999999999E+384" },
+            {  L_,          MIN,                   "1E-383" },
+            {  L_,        INF_P,                  "Infinity" },
+            {  L_,        INF_N,                 "-Infinity" },
+            {  L_,        NAN_Q,                       "NaN" },
+            //{  L_,        NAN_S,                      "sNaN" }
+        };
+        const int NUM_DATA = sizeof DATA / sizeof *DATA;
+
+        for (int ti = 0; ti < NUM_DATA; ++ti) {
+            const int    LINE       = DATA[ti].d_line;
+            const Type   DECIMAL64  = DATA[ti].d_decimalValue;
+            const char  *EXPECTED   = DATA[ti].d_expected;
+
+            if (veryVerbose) {
+                P_(LINE); P_(EXPECTED); P(DECIMAL64);
+            }
+
+            // Test with Decimal64.
+            {
+                const BDEC::Decimal64 VALUE(DECIMAL64);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+
+                BDEC::Decimal64 INPUT;
+                const int rc = Util::parseDecimal64(&INPUT, ACTUAL);
+
+                ASSERTV(LINE, EXPECTED, rc == 0);
+                if (Util::isNan(VALUE)) {
+                    ASSERTV(LINE, EXPECTED, Util::isNan(INPUT));
+                } else {
+                    ASSERTV(LINE, EXPECTED, INPUT == VALUE);
+                }
+            }
+
+            // Test with Decimal128.
+            {
+                const BDEC::Decimal128 VALUE(DECIMAL64);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+            }
+        }
+    }
+    {
+#undef DEC
+#define DEC(lit) BDLDFP_DECIMAL_DL(lit)
+        typedef bdldfp::Decimal128 Type;
+
+        Type INF_P =  bsl::numeric_limits<Type>::infinity();
+        Type INF_N = -bsl::numeric_limits<Type>::infinity();
+        Type NAN_Q =  bsl::numeric_limits<Type>::quiet_NaN();
+        Type NAN_S =  bsl::numeric_limits<Type>::signaling_NaN();
+        Type MAX   =  bdldfp::DecimalImpUtil::parse128(
+                                                     "9.999999999999999e+500");
+        Type MIN   = DEC(-1e-500);
+
+        static const struct {
+            int         d_line;
+            Type        d_decimalValue;
+            const char *d_expected;
+        } DATA[] = {
+            // L      NUMBER        EXPECTED
+            // ---    ---------     -------------------------
+            {  L_,     DEC(0.0),                      "0.0" },
+            {  L_,     DEC(1.0),                       "1.0" },
+            {  L_,  DEC(9.3E23),                   "9.3E+23" },
+            {  L_,    DEC(-1.0),                      "-1.0" },
+            {  L_,    DEC(-0.1),                      "-0.1" },
+            {  L_,    DEC(4.25),                      "4.25" },
+            {  L_,   DEC(-4.25),                     "-4.25" },
+            {  L_,          MAX,    "9.999999999999999E+500" },
+            {  L_,          MIN,                   "-1E-500" },
+            {  L_,        INF_P,                  "Infinity" },
+            {  L_,        INF_N,                 "-Infinity" },
+            {  L_,        NAN_Q,                       "NaN" },
+            {  L_,        NAN_S,                      "sNaN" }
+        };
+        const int NUM_DATA = sizeof DATA / sizeof *DATA;
+
+        for (int ti = 0; ti < NUM_DATA; ++ti) {
+            const int    LINE        = DATA[ti].d_line;
+            const Type   DECIMAL128  = DATA[ti].d_decimalValue;
+            const char  *EXPECTED    = DATA[ti].d_expected;
+
+            if (veryVerbose) {
+                P_(LINE); P_(EXPECTED); P(DECIMAL128);
+            }
+            // Test with Decimal128.
+            {
+                const BDEC::Decimal128 VALUE(DECIMAL128);
+
+                bsl::string ACTUAL(pa);
+                Util::format(VALUE, &ACTUAL);
+
+                ASSERTV(LINE, ACTUAL, EXPECTED, ACTUAL == EXPECTED);
+
+                BDEC::Decimal128 INPUT;
+                const int rc = Util::parseDecimal128(&INPUT, ACTUAL);
+
+                ASSERTV(LINE, EXPECTED, rc == 0);
+                if (Util::isNan(VALUE)) {
+                    ASSERTV(LINE, EXPECTED, Util::isNan(INPUT));
+                } else {
+                    ASSERTV(LINE, EXPECTED, INPUT == VALUE);
+                }
+            }
+        }
+    }
+#undef DEC
+}
+
 int main(int argc, char* argv[])
 {
-    int                test = argc > 1 ? atoi(argv[1]) : 0;
-    int             verbose = argc > 2;
-    int         veryVerbose = argc > 3;
-    int     veryVeryVerbose = argc > 4;
-    int veryVeryVeryVerbose = argc > 5;  // always the last
+                   test = argc > 1 ? atoi(argv[1]) : 0;
+                verbose = argc > 2;
+             veryVerbose = argc > 3;
+         veryVeryVerbose = argc > 4;
+     veryVeryVeryVerbose = argc > 5;  // always the last
 
     using bsls::AssertFailureHandlerGuard;
 
@@ -445,7 +706,7 @@ int main(int argc, char* argv[])
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
     bslma::TestAllocator  ta(veryVeryVeryVerbose);
-    bslma::TestAllocator *pa = &ta;
+    pa = &ta;
 
     typedef BDEC::DecimalUtil Util;
 
@@ -453,7 +714,9 @@ int main(int argc, char* argv[])
 
 
     switch (test) { case 0:
-
+    case 13: {
+        testCase13();
+    }
     case 12: {
         // --------------------------------------------------------------------
         // TESTING parseDecimal

--- a/groups/bdl/bdldfp/bdldfp_decimalutil.t.cpp
+++ b/groups/bdl/bdldfp/bdldfp_decimalutil.t.cpp
@@ -74,13 +74,6 @@ void aSsErT(bool condition, const char *message, int line)
     }
 }
 
-int                test;
-int             verbose;
-int         veryVerbose;
-int     veryVeryVerbose;
-int veryVeryVeryVerbose;
-static bslma::TestAllocator *pa;
-
 }  // close unnamed namespace
 
 // ============================================================================
@@ -434,11 +427,34 @@ struct NulBuf : bsl::streambuf {
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
 
-
-static void testCase13()
+int main(int argc, char* argv[])
 {
+    int                test = argc > 1 ? atoi(argv[1]) : 0;
+    int             verbose = argc > 2;
+    int         veryVerbose = argc > 3;
+    int     veryVeryVerbose = argc > 4;
+    int veryVeryVeryVerbose = argc > 5;  // always the last
 
-    // ------------------------------------------------------------------------
+    using bsls::AssertFailureHandlerGuard;
+
+    bslma::TestAllocator defaultAllocator("default", veryVeryVeryVerbose);
+    bslma::Default::setDefaultAllocator(&defaultAllocator);
+
+    bslma::TestAllocator globalAllocator("global", veryVeryVeryVerbose);
+    bslma::Default::setGlobalAllocator(&globalAllocator);
+
+    cout << "TEST " << __FILE__ << " CASE " << test << endl;
+    bslma::TestAllocator  ta(veryVeryVeryVerbose);
+    bslma::TestAllocator *pa = &ta;
+
+    typedef BDEC::DecimalUtil Util;
+
+    cout.precision(35);
+
+
+    switch (test) { case 0:
+    case 13: {
+        // ------------------------------------------------------------------------
     // TESTING format
     // Concerns: The format functions output human readable strings which
     //           can be round-tripped using the parse functions.
@@ -466,7 +482,6 @@ static void testCase13()
         Type INF_P =  bsl::numeric_limits<Type>::infinity();
         Type INF_N = -bsl::numeric_limits<Type>::infinity();
         Type NAN_Q =  bsl::numeric_limits<Type>::quiet_NaN();
-        Type NAN_S =  bsl::numeric_limits<Type>::signaling_NaN();
         Type MAX   = DEC(9.999999e+96);
         Type MIN   = DEC(-1e-95);
 
@@ -488,8 +503,7 @@ static void testCase13()
             {  L_,          MIN,          "-1E-95" },
             {  L_,        INF_P,        "Infinity" },
             {  L_,        INF_N,       "-Infinity" },
-            {  L_,        NAN_Q,             "NaN" },
-            //{  L_,        NAN_S,            "sNaN" },
+            {  L_,        NAN_Q,             "NaN" }
         };
         const int NUM_DATA = sizeof DATA / sizeof *DATA;
 
@@ -552,7 +566,6 @@ static void testCase13()
         Type INF_P =  bsl::numeric_limits<Type>::infinity();
         Type INF_N = -bsl::numeric_limits<Type>::infinity();
         Type NAN_Q =  bsl::numeric_limits<Type>::quiet_NaN();
-        Type NAN_S =  bsl::numeric_limits<Type>::signaling_NaN();
         Type MAX   =  bdldfp::DecimalImpUtil::parse64(
                                                      "9.999999999999999e+384");
         Type MIN   = DEC(1e-383);
@@ -575,8 +588,7 @@ static void testCase13()
             {  L_,          MIN,                   "1E-383" },
             {  L_,        INF_P,                  "Infinity" },
             {  L_,        INF_N,                 "-Infinity" },
-            {  L_,        NAN_Q,                       "NaN" },
-            //{  L_,        NAN_S,                      "sNaN" }
+            {  L_,        NAN_Q,                       "NaN" }
         };
         const int NUM_DATA = sizeof DATA / sizeof *DATA;
 
@@ -686,36 +698,6 @@ static void testCase13()
         }
     }
 #undef DEC
-}
-
-int main(int argc, char* argv[])
-{
-                   test = argc > 1 ? atoi(argv[1]) : 0;
-                verbose = argc > 2;
-             veryVerbose = argc > 3;
-         veryVeryVerbose = argc > 4;
-     veryVeryVeryVerbose = argc > 5;  // always the last
-
-    using bsls::AssertFailureHandlerGuard;
-
-    bslma::TestAllocator defaultAllocator("default", veryVeryVeryVerbose);
-    bslma::Default::setDefaultAllocator(&defaultAllocator);
-
-    bslma::TestAllocator globalAllocator("global", veryVeryVeryVerbose);
-    bslma::Default::setGlobalAllocator(&globalAllocator);
-
-    cout << "TEST " << __FILE__ << " CASE " << test << endl;
-    bslma::TestAllocator  ta(veryVeryVeryVerbose);
-    pa = &ta;
-
-    typedef BDEC::DecimalUtil Util;
-
-    cout.precision(35);
-
-
-    switch (test) { case 0:
-    case 13: {
-        testCase13();
     }
     case 12: {
         // --------------------------------------------------------------------


### PR DESCRIPTION
This patch adds a 'bdlfp::DecimalUtil::format(DecimalType, bsl::string *out)' functions that produce a string representation of decimal values. They do so without using streams or the locales, so the output is primarily intended for human readers. If I misunderstood this requirement.

The implementation of the format functions using 'DecNumber' as the implementation.  Another possibility would be to use the platform specific implementation provided by 'DecimalImpUtil'.

