### PR TITLE
Fix include guard typos

### DIFF
--- a/groups/bal/balber/balber_beruniversaltagnumber.h
+++ b/groups/bal/balber/balber_beruniversaltagnumber.h
@@ -139,7 +139,7 @@ BSLS_IDENT("$Id: $")
 #include <bdlat_typecategory.h>
 #endif
 
-#ifndef INCLUDED_BDLDFLP_DECIMAL
+#ifndef INCLUDED_BDLDFP_DECIMAL
 #include <bdldfp_decimal.h>
 #endif
 

--- a/groups/bbl/bblscm/bblscm_version.h
+++ b/groups/bbl/bblscm/bblscm_version.h
@@ -2,7 +2,7 @@
 #ifndef INCLUDED_BBLSCM_VERSION
 #define INCLUDED_BBLSCM_VERSION
 
-#ifndef INCLUDED_BBLS_IDENT
+#ifndef INCLUDED_BSLS_IDENT
 #include <bsls_ident.h>
 #endif
 BSLS_IDENT("$Id: $")

--- a/groups/bbl/bblscm/bblscm_versiontag.h
+++ b/groups/bbl/bblscm/bblscm_versiontag.h
@@ -2,7 +2,7 @@
 #ifndef INCLUDED_BBLSCM_VERSIONTAG
 #define INCLUDED_BBLSCM_VERSIONTAG
 
-#ifndef INCLUDED_BBLS_IDENT
+#ifndef INCLUDED_BSLS_IDENT
 #include <bsls_ident.h>
 #endif
 BSLS_IDENT("$Id: $")

--- a/groups/bdl/bdldfp/bdldfp_binaryintegraldecimalimputil.h
+++ b/groups/bdl/bdldfp/bdldfp_binaryintegraldecimalimputil.h
@@ -39,7 +39,7 @@ BSLS_IDENT("$Id$")
 #include <bdldfp_uint128.h>
 #endif
 
-#ifndef INCLUDED_DENSELYPACKEDDECIMALIMPUTIL
+#ifndef INCLUDED_BDLDFP_DENSELYPACKEDDECIMALIMPUTIL
 #include <bdldfp_denselypackeddecimalimputil.h>
 #endif
 

--- a/groups/bdl/bdls/bdls_filesystemutil.h
+++ b/groups/bdl/bdls/bdls_filesystemutil.h
@@ -309,9 +309,9 @@ BSLS_IDENT("$Id: $")
 #include <bsl_cstddef.h>
 #endif
 
-#ifndef INCLUDED_TYPES_H
+#ifndef INCLUDED_SYS_TYPES
 #include <sys/types.h>
-#define INCLUDED_TYPES_H
+#define INCLUDED_SYS_TYPES
 #endif
 
 namespace BloombergLP {

--- a/groups/bdl/bdlscm/bdlscm_versiontag.h
+++ b/groups/bdl/bdlscm/bdlscm_versiontag.h
@@ -2,7 +2,7 @@
 #ifndef INCLUDED_BDLSCM_VERSIONTAG
 #define INCLUDED_BDLSCM_VERSIONTAG
 
-#ifndef INCLUDED_BDLS_IDENT
+#ifndef INCLUDED_BSLS_IDENT
 #include <bsls_ident.h>
 #endif
 BSLS_IDENT("$Id: $")

--- a/groups/bsl/bsl+stdhdrs/algorithm
+++ b/groups/bsl/bsl+stdhdrs/algorithm
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_algorithm
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/algorithm.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/algorithm.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_algorithm
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/array
+++ b/groups/bsl/bsl+stdhdrs/array
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_array
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/array.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/array.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_array
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/assert.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/assert.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_assert
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/atomic
+++ b/groups/bsl/bsl+stdhdrs/atomic
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_atomic
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/atomic.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/atomic.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_atomic
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/bitset
+++ b/groups/bsl/bsl+stdhdrs/bitset
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_bitset
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/bitset.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/bitset.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_bitset
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/bsl_stdhdrs_epilogue_recursive.h
+++ b/groups/bsl/bsl+stdhdrs/bsl_stdhdrs_epilogue_recursive.h
@@ -326,7 +326,7 @@
 # ifndef INCLUDED_BSLMF_REMOVECONST
 #   include <bslmf_removeconst.h>
 # endif
-# ifndef INCLUDED_BSLMF_REMOVEREFRENCE
+# ifndef INCLUDED_BSLMF_REMOVEREFERENCE
 #   include <bslmf_removereference.h>
 # endif
 # ifndef INCLUDED_BSLMF_REMOVEVOLATILE

--- a/groups/bsl/bsl+stdhdrs/cassert
+++ b/groups/bsl/bsl+stdhdrs/cassert
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cassert
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cassert.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cassert.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cassert
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cctype
+++ b/groups/bsl/bsl+stdhdrs/cctype
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cctype.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cctype.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cerrno
+++ b/groups/bsl/bsl+stdhdrs/cerrno
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cerrno
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cerrno.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cerrno.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cerrno
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cfenv
+++ b/groups/bsl/bsl+stdhdrs/cfenv
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cfenv
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cfenv.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cfenv.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cfenv
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cfloat
+++ b/groups/bsl/bsl+stdhdrs/cfloat
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cfloat
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cfloat.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cfloat.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cfloat
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/chrono
+++ b/groups/bsl/bsl+stdhdrs/chrono
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_chrono
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/chrono.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/chrono.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_chrono
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cinttypes
+++ b/groups/bsl/bsl+stdhdrs/cinttypes
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cinttypes
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cinttypes.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cinttypes.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cinttypes
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ciso646
+++ b/groups/bsl/bsl+stdhdrs/ciso646
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ciso646
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ciso646.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ciso646.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ciso646
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/climits
+++ b/groups/bsl/bsl+stdhdrs/climits
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_climits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/climits.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/climits.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_climits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/clocale
+++ b/groups/bsl/bsl+stdhdrs/clocale
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_clocale
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/clocale.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/clocale.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_clocale
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cmath
+++ b/groups/bsl/bsl+stdhdrs/cmath
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cmath
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cmath.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cmath.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cmath
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/complex
+++ b/groups/bsl/bsl+stdhdrs/complex
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_complex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/complex.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/complex.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_complex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/condition_variable
+++ b/groups/bsl/bsl+stdhdrs/condition_variable
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_condition_variable
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/condition_variable.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/condition_variable.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_condition_variable
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/csetjmp
+++ b/groups/bsl/bsl+stdhdrs/csetjmp
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_csetjmp
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/csetjmp.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/csetjmp.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_csetjmp
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/csignal
+++ b/groups/bsl/bsl+stdhdrs/csignal
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_csignal
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/csignal.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/csignal.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_csignal
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdarg
+++ b/groups/bsl/bsl+stdhdrs/cstdarg
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdarg
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdarg.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstdarg.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdarg
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdbool
+++ b/groups/bsl/bsl+stdhdrs/cstdbool
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdbool
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdbool.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstdbool.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdbool
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstddef
+++ b/groups/bsl/bsl+stdhdrs/cstddef
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstddef
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstddef.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstddef.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstddef
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdint
+++ b/groups/bsl/bsl+stdhdrs/cstdint
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdint
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdint.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstdint.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdint
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdio
+++ b/groups/bsl/bsl+stdhdrs/cstdio
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdio
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdio.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstdio.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdio
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdlib
+++ b/groups/bsl/bsl+stdhdrs/cstdlib
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdlib
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstdlib.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstdlib.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstdlib
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstring
+++ b/groups/bsl/bsl+stdhdrs/cstring
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstring
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cstring.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cstring.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cstring
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ctgmath
+++ b/groups/bsl/bsl+stdhdrs/ctgmath
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ctgmath
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ctgmath.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ctgmath.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ctgmath
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ctime
+++ b/groups/bsl/bsl+stdhdrs/ctime
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ctime
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ctime.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ctime.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ctime
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ctype.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ctype.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_ctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cuchar
+++ b/groups/bsl/bsl+stdhdrs/cuchar
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cuchar
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cuchar.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cuchar.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cuchar
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cwchar
+++ b/groups/bsl/bsl+stdhdrs/cwchar
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cwchar
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cwchar.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cwchar.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cwchar
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cwctype
+++ b/groups/bsl/bsl+stdhdrs/cwctype
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cwctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/cwctype.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/cwctype.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_cwctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/deque
+++ b/groups/bsl/bsl+stdhdrs/deque
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_deque
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/deque.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/deque.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_deque
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/errno.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/errno.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -44,7 +44,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_errno
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/exception
+++ b/groups/bsl/bsl+stdhdrs/exception
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_exception
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/exception.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/exception.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_exception
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/float.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/float.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_float
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/fstream
+++ b/groups/bsl/bsl+stdhdrs/fstream
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_fstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/fstream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/fstream.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_fstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/functional
+++ b/groups/bsl/bsl+stdhdrs/functional
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_functional
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/functional.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/functional.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_functional
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/future
+++ b/groups/bsl/bsl+stdhdrs/future
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_future
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/future.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/future.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_future
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/initializer_list
+++ b/groups/bsl/bsl+stdhdrs/initializer_list
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_initializer_list
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/initializer_list.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/initializer_list.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_initializer_list
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iomanip
+++ b/groups/bsl/bsl+stdhdrs/iomanip
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iomanip
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iomanip.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/iomanip.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iomanip
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ios
+++ b/groups/bsl/bsl+stdhdrs/ios
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ios
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ios.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ios.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ios
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iosfwd
+++ b/groups/bsl/bsl+stdhdrs/iosfwd
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iosfwd
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iosfwd.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/iosfwd.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iosfwd
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iostream
+++ b/groups/bsl/bsl+stdhdrs/iostream
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iostream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iostream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/iostream.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iostream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iso646.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/iso646.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_iso646
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/istream
+++ b/groups/bsl/bsl+stdhdrs/istream
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_istream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/istream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/istream.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_istream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iterator
+++ b/groups/bsl/bsl+stdhdrs/iterator
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iterator
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/iterator.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/iterator.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_iterator
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/limits
+++ b/groups/bsl/bsl+stdhdrs/limits
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_limits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/limits.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/limits.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_limits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/limits.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/limits.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_limits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/list
+++ b/groups/bsl/bsl+stdhdrs/list
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_list
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/list.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/list.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_list
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/locale
+++ b/groups/bsl/bsl+stdhdrs/locale
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_locale
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/locale.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/locale.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_locale
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/locale.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/locale.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_locale
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/map
+++ b/groups/bsl/bsl+stdhdrs/map
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_map
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/map.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/map.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_map
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/math.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/math.h.SUNWCCh
@@ -36,7 +36,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -53,7 +53,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_math
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/memory
+++ b/groups/bsl/bsl+stdhdrs/memory
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_memory
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/memory.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/memory.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_memory
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/mutex
+++ b/groups/bsl/bsl+stdhdrs/mutex
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_mutex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/mutex.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/mutex.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_mutex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/new
+++ b/groups/bsl/bsl+stdhdrs/new
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_new
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/new.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/new.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_new
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/numeric
+++ b/groups/bsl/bsl+stdhdrs/numeric
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_numeric
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/numeric.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/numeric.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_numeric
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ostream
+++ b/groups/bsl/bsl+stdhdrs/ostream
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ostream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ostream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ostream.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ostream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/queue
+++ b/groups/bsl/bsl+stdhdrs/queue
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_queue
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/queue.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/queue.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_queue
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/random
+++ b/groups/bsl/bsl+stdhdrs/random
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_random
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/random.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/random.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_random
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ratio
+++ b/groups/bsl/bsl+stdhdrs/ratio
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ratio
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/ratio.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/ratio.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_ratio
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/regex
+++ b/groups/bsl/bsl+stdhdrs/regex
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_regex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/regex.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/regex.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_regex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/scoped_allocator
+++ b/groups/bsl/bsl+stdhdrs/scoped_allocator
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_scoped_allocator
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/scoped_allocator.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/scoped_allocator.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_scoped_allocator
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/scoped_allocator.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/scoped_allocator.SUNWCCh
@@ -1,6 +1,6 @@
 // scoped_allocator                                                   -*-C++-*-
 #ifndef INCLUDED_NATIVE_SCOPED_ALLOCATOR
-#define INCLUDED_NATIVE_SCOPED_ALLOCATAOR
+#define INCLUDED_NATIVE_SCOPED_ALLOCATOR
 
 #ifndef INCLUDED_BSLS_IDENT
 #include <bsls_ident.h>

--- a/groups/bsl/bsl+stdhdrs/set
+++ b/groups/bsl/bsl+stdhdrs/set
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_set
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/set.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/set.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_set
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/setjmp.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/setjmp.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_setjmp
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/signal.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/signal.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_signal
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/sstream
+++ b/groups/bsl/bsl+stdhdrs/sstream
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_sstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/sstream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/sstream.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_sstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stack
+++ b/groups/bsl/bsl+stdhdrs/stack
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_stack
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stack.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stack.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_stack
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stdarg.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stdarg.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_stdarg
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stddef.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stddef.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_stddef
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stdexcept
+++ b/groups/bsl/bsl+stdhdrs/stdexcept
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_stdexcept
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stdexcept.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stdexcept.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_stdexcept
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stdio.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stdio.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_stdio
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/stdlib.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/stdlib.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_stdlib
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/streambuf
+++ b/groups/bsl/bsl+stdhdrs/streambuf
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_streambuf
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/streambuf.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/streambuf.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_streambuf
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/string
+++ b/groups/bsl/bsl+stdhdrs/string
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_string
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/string.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/string.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_string
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/string.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/string.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_string
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/strstream
+++ b/groups/bsl/bsl+stdhdrs/strstream
@@ -29,7 +29,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -50,7 +50,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_strstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/strstream.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/strstream.SUNWCCh
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -42,7 +42,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_strstream
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/sys/time.h
+++ b/groups/bsl/bsl+stdhdrs/sys/time.h
@@ -27,7 +27,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -48,7 +48,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_sys_time
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/sys/time.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/sys/time.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_sys_time
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/system_error
+++ b/groups/bsl/bsl+stdhdrs/system_error
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_system_error
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/system_error.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/system_error.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_system_error
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/thread
+++ b/groups/bsl/bsl+stdhdrs/thread
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_thread
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/thread.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/thread.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_thread
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/time.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/time.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_time
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/tuple
+++ b/groups/bsl/bsl+stdhdrs/tuple
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_tuple
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/tuple.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/tuple.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_tuple
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/type_traits
+++ b/groups/bsl/bsl+stdhdrs/type_traits
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #     include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -48,7 +48,7 @@ BSLS_IDENT("$Id: $")
 #   endif
 # endif
 #
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #     include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/type_traits.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/type_traits.SUNWCCh
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_type_traits
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/typeindex
+++ b/groups/bsl/bsl+stdhdrs/typeindex
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_typeindex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/typeindex.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/typeindex.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_typeindex
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/typeinfo
+++ b/groups/bsl/bsl+stdhdrs/typeinfo
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_typeinfo
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/typeinfo.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/typeinfo.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_typeinfo
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/unordered_map
+++ b/groups/bsl/bsl+stdhdrs/unordered_map
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_unordered_map
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/unordered_map.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/unordered_map.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_unordered_map
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/unordered_set
+++ b/groups/bsl/bsl+stdhdrs/unordered_set
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_unordered_set
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/unordered_set.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/unordered_set.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_unordered_set
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/utility
+++ b/groups/bsl/bsl+stdhdrs/utility
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_utility
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/utility.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/utility.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_utility
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/valarray
+++ b/groups/bsl/bsl+stdhdrs/valarray
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_valarray
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/valarray.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/valarray.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_valarray
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/vector
+++ b/groups/bsl/bsl+stdhdrs/vector
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -46,7 +46,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_vector
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/vector.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/vector.SUNWCCh
@@ -21,7 +21,7 @@ BSLS_IDENT("$Id: $")
 
 #ifndef BSL_OVERRIDES_STD
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -38,7 +38,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_vector
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/wchar.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/wchar.h.SUNWCCh
@@ -30,7 +30,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -47,7 +47,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_wchar
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bsl+stdhdrs/wctype.h.SUNWCCh
+++ b/groups/bsl/bsl+stdhdrs/wctype.h.SUNWCCh
@@ -23,7 +23,7 @@ BSLS_IDENT("$Id: $")
 
 #if !defined(BSL_OVERRIDES_STD) || !defined(__cplusplus)
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 
@@ -40,7 +40,7 @@ BSLS_IDENT("$Id: $")
 #   define BSL_STDHDRS_EPILOGUE_RUN_BY_c_wctype
 #   endif
 
-#   ifndef INCLUDED_BSL_STDHDRS_INCPATH
+#   ifndef INCLUDED_BSL_STDHDRS_INCPATHS
 #   include <bsl_stdhdrs_incpaths.h>
 #   endif
 

--- a/groups/bsl/bslmt/bslmt_saturatedtimeconversionimputil.h
+++ b/groups/bsl/bslmt/bslmt_saturatedtimeconversionimputil.h
@@ -132,15 +132,15 @@ BSLS_IDENT("$Id: $")
 #endif
 
 #ifndef INCLUDED_TIME_H
-#define INCLUDED_TIME_H
 #include <time.h>   // POSIX timespec
+#define INCLUDED_TIME_H
 #endif
 
 #ifdef BSLS_PLATFORM_OS_DARWIN
 
 #ifndef INCLUDED_MACH_CLOCK_TYPES
-#define INCLUDED_MACH_CLOCK_TYPES
 #include <mach/clock_types.h>    // for 'mach_timespec_t'
+#define INCLUDED_MACH_CLOCK_TYPES
 #endif
 
 #endif

--- a/groups/btl/btlmt/btlmt_channelpool.h
+++ b/groups/btl/btlmt/btlmt_channelpool.h
@@ -593,15 +593,15 @@ BSLS_IDENT("$Id: $")
 #include <btlb_pooledblobbufferfactory.h>
 #endif
 
-#ifndef INCLUDED_bslmt_MUTEX
+#ifndef INCLUDED_BSLMT_MUTEX
 #include <bslmt_mutex.h>
 #endif
 
-#ifndef INCLUDED_bslmt_THREADUTIL
+#ifndef INCLUDED_BSLMT_THREADUTIL
 #include <bslmt_threadutil.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btlmt/btlmt_channelpoolconfiguration.h
+++ b/groups/btl/btlmt/btlmt_channelpoolconfiguration.h
@@ -226,7 +226,7 @@ BSLS_IDENT("$Id: $")
 #include <bslalg_typetraits.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btlmt/btlmt_tcptimereventmanager.h
+++ b/groups/btl/btlmt/btlmt_tcptimereventmanager.h
@@ -257,7 +257,7 @@ BSLS_IDENT("$Id: $")
 #include <bsls_atomic.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btls5/btls5_negotiator.h
+++ b/groups/btl/btls5/btls5_negotiator.h
@@ -146,7 +146,7 @@ BSLS_IDENT("$Id: $")
 #include <btlso_streamsocket.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btls5/btls5_networkconnector.h
+++ b/groups/btl/btls5/btls5_networkconnector.h
@@ -174,7 +174,7 @@ BSLS_IDENT("$Id: $")
 #include <btlso_streamsocketfactory.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btls5/btls5_testserver.h
+++ b/groups/btl/btls5/btls5_testserver.h
@@ -79,7 +79,7 @@ BSLS_IDENT("$Id: $")
 #include <btlso_endpoint.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/groups/btl/btlso/btlso_inetstreamsocket.h
+++ b/groups/btl/btlso/btlso_inetstreamsocket.h
@@ -157,7 +157,7 @@ BSLS_IDENT("$Id: $")
 #include <bdlt_currenttime.h>
 #endif
 
-#ifndef INCLUDED_BDLT_TIMEINTERVAL
+#ifndef INCLUDED_BSLS_TIMEINTERVAL
 #include <bsls_timeinterval.h>
 #endif
 

--- a/samples/object_pool/pkg_objectpool.h
+++ b/samples/object_pool/pkg_objectpool.h
@@ -44,11 +44,11 @@
 //
 //      // ..
 //
-//      bslma::Allocator d_allocator_p;   // memory allocator (held, not owned)
+//      bslma::Allocator *d_allocator_p;   // memory allocator (held, not owned)
 //
 //    public:
 //      // CREATORS
-//      DatabaseConnection(bslma::Allocator basicAllocator = 0);
+//      DatabaseConnection(bslma::Allocator *basicAllocator = 0);
 //          // Create a 'DatabaseConnection' object.  Optionally specify a
 //          // 'basicAllocator' used to supply memory.  If 'basicAllocator' is
 //          // 0, the currently installed default allocator is used.

--- a/thirdparty/decnumber/wscript
+++ b/thirdparty/decnumber/wscript
@@ -18,7 +18,7 @@ def configure(conf):
     conf.load('compiler_c')
 
 def build(bld):
-    # This set of c source files correspond to the set of modules mentioned in
+    # This set of c source files corresponds to the set of modules mentioned in
     # the "Modules" section of the decNumber documentation
     # (http://speleotrove.com/decimal/decnumber.html).
     source_files = [


### PR DESCRIPTION
Although `INCLUDED_BSL_STDHDRS_INCPATH` is never defined, it's used in 170 files. I fix it (by adding an `S` to the end) in a separate commit to make the other changes easier to review.