### PR TITLE
Fix warnings as errors with gcc 6.2.1

### DIFF
--- a/groups/bdl/bdlb/bdlb_bitmaskutil.h
+++ b/groups/bdl/bdlb/bdlb_bitmaskutil.h
@@ -252,7 +252,7 @@ bsl::uint32_t BitMaskUtil::ge(int index)
 
     return BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
                                    index < static_cast<int>(k_BITS_PER_UINT32))
-           ? (~0 << index)
+           ? (~static_cast<uint32_t>(0) << index)
            : 0;
 }
 

--- a/groups/bsl/bslstl/bslstl_hashtable.cpp
+++ b/groups/bsl/bslstl/bslstl_hashtable.cpp
@@ -76,7 +76,7 @@ size_t HashTable_ImpDetails::growBucketsForLoadFactor(size_t *capacity,
          result *= 2) {
         result = nextPrime(result);  // throws if too large
         double newCapacity = static_cast<double>(result) * maxLoadFactor;
-        if (minElements <= newCapacity) {
+        if (static_cast<double>(minElements) <= newCapacity) {
             // Set '*capacity' to the integer value corresponding to
             // 'newCapacity', or the highest unsigned value representable by
             // 'size_t' if 'newCapacity' is larger.


### PR DESCRIPTION
When building with gcc 6.2.1 there were two warnings treated as errors which prevented building the bslstl package and the libraries.  Here are the fixes I made to get them to compile cleanly.
