### PR TITLE
fix GCC 7 compiler warning

### DIFF
--- a/groups/bdl/bdlb/bdlb_variant.h
+++ b/groups/bdl/bdlb/bdlb_variant.h
@@ -5936,7 +5936,7 @@ struct Variant_TypeIndex {
               : 0
     };
 
-    BSLMF_ASSERT(value);
+    BSLMF_ASSERT(0 != value);
 
 #if defined(BDLB_VARIANT_USING_VARIADIC_TEMPLATES)
     // See 'testCase17' in the test driver for code snippets that motivate this
@@ -7683,7 +7683,7 @@ template <class TYPE>
 inline
 TYPE& VariantImp<TYPES>::the()
 {
-    BSLMF_ASSERT((Variant_TypeIndex<TYPES, TYPE>::value));
+    BSLMF_ASSERT(0 != (Variant_TypeIndex<TYPES, TYPE>::value));
     BSLS_ASSERT_SAFE((this->d_type == Variant_TypeIndex<TYPES, TYPE>::value));
 
     typedef bsls::ObjectBuffer<TYPE> BufferType;
@@ -7800,7 +7800,7 @@ template <class TYPE>
 inline
 const TYPE& VariantImp<TYPES>::the() const
 {
-    BSLMF_ASSERT((Variant_TypeIndex<TYPES, TYPE>::value));
+    BSLMF_ASSERT(0 != (Variant_TypeIndex<TYPES, TYPE>::value));
     BSLS_ASSERT_SAFE((this->d_type == Variant_TypeIndex<TYPES, TYPE>::value));
 
     typedef bsls::ObjectBuffer<TYPE> BufferType;


### PR DESCRIPTION
this addresses a compiler warning seen under GCC 7.1 in a few locations: "enum constant in boolean context [-Werror=int-in-bool-context]"