### PR TITLE
Fix build error caused by BSLS_NOTHROW_SPEC not being defined.

### DIFF
--- a/groups/bdl/bdldfp/bdldfp_decimalimputil.h
+++ b/groups/bdl/bdldfp/bdldfp_decimalimputil.h
@@ -168,6 +168,10 @@ BSLS_IDENT("$Id$")
 #include <bsl_cmath.h>
 #endif
 
+#ifndef INCLUDED_BSLS_EXCEPTIONUTIL
+#include <bsls_exceptionutil.h>
+#endif
+
 #ifdef BDLDFP_DECIMALPLATFORM_SOFTWARE
 
                 // DECIMAL FLOATING-POINT LITERAL EMULATION


### PR DESCRIPTION
I checked out BDE and tried to build it, but got lots of build errors like this:

```
In file included from groups/bdl/bdldfp/bdldfp_decimalimputil.cpp:2:0:
/opt/work/semmle_data/projects/bde/revision-2018-January-29--16-51-26/bde/groups/bdl/bdldfp/bdldfp_decimalimputil.h:984:23: error: expected ';' at end of member declaration
     ValueType32 min32() BSLS_NOTHROW_SPEC;
                       ^
```

The problem is that `BSLS_NOTHROW_SPEC` is not defined. Including `bsls_exceptionutil.h` fixes the problem.