### PR TITLE
Fixed a compilation error on OS X and Ubuntu when the library is buil…

### DIFF
--- a/groups/bdl/bdldfp/bdldfp_decimalimputil.h
+++ b/groups/bdl/bdldfp/bdldfp_decimalimputil.h
@@ -6,6 +6,7 @@
 #ifndef INCLUDED_BSLS_IDENT
 #include <bsls_ident.h>
 #endif
+#include <bsls_exceptionutil.h>
 BSLS_IDENT("$Id$")
 
 //@PURPOSE: Provide a unified low-level interface for decimal floating point.


### PR DESCRIPTION
Fixed a compilation error on OS X and Ubuntu when the library is build on a clean machine - the BSLS_NOTHROW_SPEC has not been defined in some source files