### PR TITLE
Fixed assignment of prvalue char to char*

### DIFF
--- a/groups/bsl/bslalg/bslalg_arrayprimitives.t.cpp
+++ b/groups/bsl/bslalg/bslalg_arrayprimitives.t.cpp
@@ -1444,7 +1444,7 @@ class LargeBitwiseMoveableTestType : public TestType {
                                  bslma::Allocator        *ba = 0)   // IMPLICIT
     : TestType(ba)
     {
-        d_data_p = cE.d_c;
+        *d_data_p = cE.d_c;
         for (int i = 0; i < FOOTPRINT; ++i) {
             d_junk[i] = i;
         }


### PR DESCRIPTION
Don't know why this isn't caught with gcc. d_data_p is a member of the non-dependent base TestType. However explicit instantiation of LargeBitwiseMoveableTestType manifests the error with gcc.