### PR TITLE
Patch to compile with Apple Clang 11 in C++17 mode

### DIFF
--- a/groups/bal/balst/balst_stacktrace.t.cpp
+++ b/groups/bal/balst/balst_stacktrace.t.cpp
@@ -720,6 +720,8 @@ int main(int argc, char *argv[])
         if (verbose) cout <<
                 "\nAssign the address of each function to a variable." << endl;
         {
+            using balst::swap;
+
             typedef void (Obj::*funcPtr)(Obj&);
             typedef void (*freeFuncPtr)(Obj&, Obj&);
 

--- a/groups/bal/balst/balst_stacktraceresolverimpl_dladdr.t.cpp
+++ b/groups/bal/balst/balst_stacktraceresolverimpl_dladdr.t.cpp
@@ -19,6 +19,7 @@
 #include <bslma_testallocator.h>
 #include <bsls_types.h>
 
+#include <bsl_algorithm.h>
 #include <bsl_cmath.h>
 #include <bsl_cstdio.h>
 #include <bsl_cstdlib.h>

--- a/groups/bal/baltzo/baltzo_localdatetime.t.cpp
+++ b/groups/bal/baltzo/baltzo_localdatetime.t.cpp
@@ -1583,6 +1583,8 @@ int main(int argc, char *argv[])
         if (verbose) cout <<
                 "\nAssign the address of each function to a variable." << endl;
         {
+            using baltzo::swap;
+
             typedef void (Obj::*funcPtr)(Obj&);
             typedef void (*freeFuncPtr)(Obj&, Obj&);
 

--- a/groups/bsl/bslmf/bslmf_ismemberpointer.t.cpp
+++ b/groups/bsl/bslmf/bslmf_ismemberpointer.t.cpp
@@ -165,8 +165,8 @@ void aSsErT(bool condition, const char *message, int line)
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_VARIABLE_TEMPLATES)
 # define ASSERT_V_EQ_VALUE(TYPE)                                              \
-    ASSERT(bsl::is_member_object_pointer  <TYPE>::value ==                  \
-           bsl::is_member_object_pointer_v<TYPE>)
+    ASSERT(bsl::is_member_pointer  <TYPE>::value ==                           \
+           bsl::is_member_pointer_v<TYPE>)
     // Test whether 'bsl::is_member_object_pointer_v<TYPE>' value equals to
     // 'bsl::is_member_object_pointer<TYPE>::value'.
 #else

--- a/groups/bsl/bslmf/bslmf_istriviallycopyable.cpp
+++ b/groups/bsl/bslmf/bslmf_istriviallycopyable.cpp
@@ -10,6 +10,7 @@ BSLS_IDENT("$Id$ $CSID$")
 #include <bslmf_addpointer.h>               // for testing only
 #include <bslmf_addvolatile.h>              // for testing only
 #include <bslmf_nestedtraitdeclaration.h>   // for testing only
+#include <bslmf_nil.h>                      // for testing only
 #include <bslmf_removevolatile.h>           // for testing only
 
 // ----------------------------------------------------------------------------

--- a/groups/bsl/bslmf/bslmf_istriviallycopyable.t.cpp
+++ b/groups/bsl/bslmf/bslmf_istriviallycopyable.t.cpp
@@ -8,6 +8,7 @@
 #include <bslmf_addpointer.h>
 #include <bslmf_addvolatile.h>
 #include <bslmf_nestedtraitdeclaration.h>
+#include <bslmf_nil.h>
 #include <bslmf_removevolatile.h>  // gcc workaround
 
 #include <bsls_bsltestutil.h>


### PR DESCRIPTION
When compiling natively on macOS with the latest Apple Clang
compiler (v11) there are a small number of compile errors
induced by the pickier compiler.  This patch resolves all
compile failures on my own machine.  I have built and run
all packages and test drivers.
