### PR TITLE
Make gcc-9 work on Darwin

### DIFF
--- a/groups/bsl/bsls/bsls_libraryfeatures.h
+++ b/groups/bsl/bsls/bsls_libraryfeatures.h
@@ -1032,8 +1032,14 @@ BSLS_IDENT("$Id: $")
            (defined(__GXX_EXPERIMENTAL_CXX0X__) &&                            \
             BSLS_PLATFORM_CMP_VERSION >= 40800)
         // C99 functions are available in C++11 builds.
-
         #define BSLS_LIBRARYFEATURES_HAS_C99_LIBRARY                  1
+    #endif
+    #if (__cplusplus >= 201103L) ||                                           \
+           (defined(__GXX_EXPERIMENTAL_CXX0X__) &&                            \
+            BSLS_PLATFORM_CMP_VERSION >= 40800) ||                            \
+            (defined(_GLIBCXX_USE_C99) && _GLIBCXX_USE_C99 == 1)
+        // snprintf is also available in C++03 builds with new gcc versions
+
         #define BSLS_LIBRARYFEATURES_HAS_C99_SNPRINTF                 1
     #endif
     #if defined(__GXX_EXPERIMENTAL_CXX0X__) && (__cplusplus >= 201103L)

--- a/groups/bsl/bslstl/bslstl_error.h
+++ b/groups/bsl/bslstl/bslstl_error.h
@@ -710,7 +710,7 @@ struct hash<bsl::error_condition> : BloombergLP::bslh::Hash<>
 
 namespace std {
 
-#ifndef BSLS_PLATFORM_OS_DARWIN
+#if !defined(BSLS_PLATFORM_OS_DARWIN) || defined (BSLS_PLATFORM_CMP_GNU)
   // On C++03 on Darwin, the template struct 'hash' is forward declared with
   // different attributes in <typetraits> that conflict with this forward
   // declaration.


### PR DESCRIPTION
Code fixes for gcc-9 on Darwin.  @AlisdairM to check under MacPorts.