### PR TITLE
First round of C++20 fixes

### DIFF
--- a/groups/bal/balber/balber_berutil.h
+++ b/groups/bal/balber/balber_berutil.h
@@ -2328,14 +2328,14 @@ struct BerUtil_TimeImpUtil {
     // PRIVATE TYPES
     enum {
         k_EXTENDED_BINARY_TIME_LENGTH =
-            DateAndTimeHeaderUtil::k_HEADER_LENGTH +
-            IntegerUtil::k_40_BIT_INTEGER_LENGTH,  // = 7
+            +DateAndTimeHeaderUtil::k_HEADER_LENGTH +
+            +IntegerUtil::k_40_BIT_INTEGER_LENGTH,  // = 7
         // the number of content octets used by 'BerUtil' to encode
         // a time value using the extended-binary time and time zone format
 
         k_EXTENDED_BINARY_TIMETZ_LENGTH =
-            DateAndTimeHeaderUtil::k_HEADER_LENGTH +
-            IntegerUtil::k_40_BIT_INTEGER_LENGTH,  // = 7
+            +DateAndTimeHeaderUtil::k_HEADER_LENGTH +
+            +IntegerUtil::k_40_BIT_INTEGER_LENGTH,  // = 7
         // the number of contents octets used by 'BerUtil' to encode
         // a time and time zone value using the extended-binary time and
         // time zone format

--- a/groups/bal/balm/balm_stopwatchscopedguard.h
+++ b/groups/bal/balm/balm_stopwatchscopedguard.h
@@ -417,7 +417,7 @@ inline
 StopwatchScopedGuard::~StopwatchScopedGuard()
 {
     if (isActive()) {
-        d_collector_p->update(d_stopwatch.elapsedTime() * d_timeUnits);
+        d_collector_p->update(d_stopwatch.elapsedTime() * +d_timeUnits);
     }
 }
 

--- a/groups/bdl/bdlde/bdlde_charconvertutf16.t.cpp
+++ b/groups/bdl/bdlde/bdlde_charconvertutf16.t.cpp
@@ -5973,7 +5973,7 @@ int main(int argc, char**argv)
                             cout << (char) w << endl;
                         }
                         else {
-                            cout << w << endl;
+                            cout << +w << endl;
                         }
                     }
                 }

--- a/groups/bdl/bdlde/bdlde_md5.h
+++ b/groups/bdl/bdlde/bdlde_md5.h
@@ -104,6 +104,7 @@ BSLS_IDENT("$Id: $")
 #include <bdlscm_version.h>
 
 #include <bsls_alignedbuffer.h>
+#include <bsls_compilerfeatures.h>
 #include <bsls_types.h>
 
 #include <bsl_cstring.h>
@@ -178,7 +179,9 @@ class Md5 {
         // Destroy this MD5 digest.
 
     // MANIPULATORS
-    // !Md5& operator=(const Md5& rhs);
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    Md5& operator=(const Md5& rhs) = default;
+#endif
         // Assign to this MD5 digest the value of the specified 'rhs' MD5
         // digest and return a reference to this modifiable MD5 digest.  Note
         // that this method's definition is compiler generated.

--- a/groups/bdl/bdlf/bdlf_bind.h
+++ b/groups/bdl/bdlf/bdlf_bind.h
@@ -5013,36 +5013,36 @@ struct Bind_CalcParameterMask {
         // be 0.  For nested 'Bind' types, the out-of-range value 31 will be
         // used.
 
-      , k_PARAM_MASK = Bind_ArgumentMask<Type1 >::k_VaL |
-                     Bind_ArgumentMask<Type2 >::k_VaL |
-                     Bind_ArgumentMask<Type3 >::k_VaL |
-                     Bind_ArgumentMask<Type4 >::k_VaL |
-                     Bind_ArgumentMask<Type5 >::k_VaL |
-                     Bind_ArgumentMask<Type6 >::k_VaL |
-                     Bind_ArgumentMask<Type7 >::k_VaL |
-                     Bind_ArgumentMask<Type8 >::k_VaL |
-                     Bind_ArgumentMask<Type9 >::k_VaL |
-                     Bind_ArgumentMask<Type10>::k_VaL |
-                     Bind_ArgumentMask<Type11>::k_VaL |
-                     Bind_ArgumentMask<Type12>::k_VaL |
-                     Bind_ArgumentMask<Type13>::k_VaL |
-                     Bind_ArgumentMask<Type14>::k_VaL
+      , k_PARAM_MASK = +Bind_ArgumentMask<Type1 >::k_VaL |
+                       +Bind_ArgumentMask<Type2 >::k_VaL |
+                       +Bind_ArgumentMask<Type3 >::k_VaL |
+                       +Bind_ArgumentMask<Type4 >::k_VaL |
+                       +Bind_ArgumentMask<Type5 >::k_VaL |
+                       +Bind_ArgumentMask<Type6 >::k_VaL |
+                       +Bind_ArgumentMask<Type7 >::k_VaL |
+                       +Bind_ArgumentMask<Type8 >::k_VaL |
+                       +Bind_ArgumentMask<Type9 >::k_VaL |
+                       +Bind_ArgumentMask<Type10>::k_VaL |
+                       +Bind_ArgumentMask<Type11>::k_VaL |
+                       +Bind_ArgumentMask<Type12>::k_VaL |
+                       +Bind_ArgumentMask<Type13>::k_VaL |
+                       +Bind_ArgumentMask<Type14>::k_VaL
          // Mask of which parameters are place-holders.
 
-       , k_PARAM_MASK2 = Bind_ArgumentMask<Type1 >::k_VaL +
-                       Bind_ArgumentMask<Type2 >::k_VaL +
-                       Bind_ArgumentMask<Type3 >::k_VaL +
-                       Bind_ArgumentMask<Type4 >::k_VaL +
-                       Bind_ArgumentMask<Type5 >::k_VaL +
-                       Bind_ArgumentMask<Type6 >::k_VaL +
-                       Bind_ArgumentMask<Type7 >::k_VaL +
-                       Bind_ArgumentMask<Type8 >::k_VaL +
-                       Bind_ArgumentMask<Type9 >::k_VaL +
-                       Bind_ArgumentMask<Type10>::k_VaL +
-                       Bind_ArgumentMask<Type11>::k_VaL +
-                       Bind_ArgumentMask<Type12>::k_VaL +
-                       Bind_ArgumentMask<Type13>::k_VaL +
-                       Bind_ArgumentMask<Type14>::k_VaL
+       , k_PARAM_MASK2 = +Bind_ArgumentMask<Type1 >::k_VaL +
+                         +Bind_ArgumentMask<Type2 >::k_VaL +
+                         +Bind_ArgumentMask<Type3 >::k_VaL +
+                         +Bind_ArgumentMask<Type4 >::k_VaL +
+                         +Bind_ArgumentMask<Type5 >::k_VaL +
+                         +Bind_ArgumentMask<Type6 >::k_VaL +
+                         +Bind_ArgumentMask<Type7 >::k_VaL +
+                         +Bind_ArgumentMask<Type8 >::k_VaL +
+                         +Bind_ArgumentMask<Type9 >::k_VaL +
+                         +Bind_ArgumentMask<Type10>::k_VaL +
+                         +Bind_ArgumentMask<Type11>::k_VaL +
+                         +Bind_ArgumentMask<Type12>::k_VaL +
+                         +Bind_ArgumentMask<Type13>::k_VaL +
+                         +Bind_ArgumentMask<Type14>::k_VaL
         // Mask of which parameters are place-holder calculated by addition
         // rather the by ORing.  If the given place-holder is used for multiple
         // arguments, the result of mask will be different from the ORed value

--- a/groups/bsl/bsl+bslhdrs/bsl_utility.h
+++ b/groups/bsl/bsl+bslhdrs/bsl_utility.h
@@ -17,6 +17,7 @@ BSLS_IDENT("$Id: $")
 
 #include <bslmf_integersequence.h>
 #include <bslmf_makeintegersequence.h>
+#include <bslmf_matchanytype.h>
 #include <bsls_libraryfeatures.h>
 #include <bsls_nativestd.h>
 
@@ -39,7 +40,6 @@ namespace bsl {
 #endif  // BSL_OVERRIDES_STD
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_BASELINE_LIBRARY
-    using native_std::declval;
     using native_std::forward;
     using native_std::move;
     using native_std::move_if_noexcept;

--- a/groups/bsl/bslalg/bslalg_containerbase.h
+++ b/groups/bsl/bslalg/bslalg_containerbase.h
@@ -86,6 +86,7 @@ BSLS_IDENT("$Id: $")
 #include <bslscm_version.h>
 
 #include <bslma_allocator.h>
+#include <bslma_allocatortraits.h>
 
 #include <bslmf_conditional.h>
 #include <bslmf_isconvertible.h>
@@ -244,6 +245,20 @@ class ContainerBase : public
                   ContainerBase_BslmaBase<ALLOCATOR>,
                   ContainerBase_NonBslmaBase<ALLOCATOR> >::type Base;
 
+  public:
+    // PUBLIC TYPES
+    typedef typename Base::AllocatorType              AllocatorType;
+    typedef bsl::allocator_traits<AllocatorType>      AllocatorTraits;
+
+    typedef typename AllocatorTraits::size_type       size_type;
+    typedef typename AllocatorTraits::difference_type difference_type;
+    typedef typename AllocatorTraits::pointer         pointer;
+    typedef typename AllocatorTraits::const_pointer   const_pointer;
+    typedef typename AllocatorTraits::value_type      value_type;
+
+        // Restate required allocator types.  (Reduces use of 'typename' in
+        // interface.)
+
   private:
     // NOT IMPLEMENTED
     ContainerBase& operator=(const ContainerBase&);
@@ -251,29 +266,16 @@ class ContainerBase : public
   private:
     // PRIVATE MANIPULATORS
     template <class T>
-    typename ALLOCATOR::template rebind<T>::other
+    typename AllocatorTraits::template rebind_alloc<T>
     rebindAllocator(T*)
         // Return 'this->allocator()' rebound for type 'T'.  The 'T*' argument
         // is used only for template parameter deduction and is ignored.
     {
-        typedef typename ALLOCATOR::template rebind<T>::other Rebound;
+        typedef typename AllocatorTraits::template rebind_alloc<T> Rebound;
         return Rebound(this->allocator());
     }
 
   public:
-    // PUBLIC TYPES
-    typedef typename Base::AllocatorType            AllocatorType;
-
-    typedef typename AllocatorType::size_type       size_type;
-    typedef typename AllocatorType::difference_type difference_type;
-    typedef typename AllocatorType::pointer         pointer;
-    typedef typename AllocatorType::const_pointer   const_pointer;
-    typedef typename AllocatorType::reference       reference;
-    typedef typename AllocatorType::const_reference const_reference;
-    typedef typename AllocatorType::value_type      value_type;
-        // Restate required allocator types.  (Reduces use of 'typename' in
-        // interface.)
-
     // CREATORS
     ContainerBase(const ALLOCATOR& basicAllocator);
         // Construct this object using the specified 'basicAllocator' of the

--- a/groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp
+++ b/groups/bsl/bslalg/bslalg_dequeprimitives.t.cpp
@@ -501,7 +501,7 @@ class TestTypeNoAlloc {
         ++numCharCtorCalls;
     }
 
-    TestTypeNoAlloc(const TestTypeNoAlloc&  original)
+    TestTypeNoAlloc(const TestTypeNoAlloc& original)
     {
         d_u.d_char = original.d_u.d_char;
         ++numCopyCtorCalls;
@@ -568,6 +568,11 @@ class BitwiseMoveableTestType : public TestType {
     : TestType(original, ba)
     {
     }
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    BitwiseMoveableTestType&
+    operator=(const BitwiseMoveableTestType& other) = default;
+#endif
 };
 
 // TRAITS
@@ -604,10 +609,15 @@ class BitwiseCopyableTestType : public TestTypeNoAlloc {
         ++numCharCtorCalls;
     }
 
-    BitwiseCopyableTestType(const BitwiseCopyableTestType&  original)
+    BitwiseCopyableTestType(const BitwiseCopyableTestType& original)
     : TestTypeNoAlloc(original.datum())
     {
     }
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    BitwiseCopyableTestType&
+    operator=(const BitwiseCopyableTestType& other) = default;
+#endif
 };
 
 // TRAITS

--- a/groups/bsl/bslim/bslim_testutil.h
+++ b/groups/bsl/bslim/bslim_testutil.h
@@ -148,49 +148,51 @@ BSLS_IDENT("$Id: $")
 #define BSLIM_TESTUTIL_ASSERT(X)                                              \
     aSsErT(!(X), #X, __LINE__);
 
+#define BSLIM_TESTUTIL_DEBUG_REP(X) BloombergLP::bslim::TestUtil::debugRep(X)
+
 #define BSLIM_TESTUTIL_LOOP0_ASSERT                                           \
     BSLIM_TESTUTIL_ASSERT
 
 #define BSLIM_TESTUTIL_LOOP_ASSERT(I,X)                                       \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\n";\
                 aSsErT(1, #X, __LINE__); }
 
 #define BSLIM_TESTUTIL_LOOP1_ASSERT                                           \
     BSLIM_TESTUTIL_LOOP_ASSERT
 
 #define BSLIM_TESTUTIL_LOOP2_ASSERT(I,J,X)                                    \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\t"                        \
-                          << #J << ": " << (J) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\t"\
+                          << #J << ": " << BSLIM_TESTUTIL_DEBUG_REP(J) << "\n";\
                 aSsErT(1, #X, __LINE__); }
 
 #define BSLIM_TESTUTIL_LOOP3_ASSERT(I,J,K,X)                                  \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\t"                        \
-                          << #J << ": " << (J) << "\t"                        \
-                          << #K << ": " << (K) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\t"\
+                          << #J << ": " << BSLIM_TESTUTIL_DEBUG_REP(J) << "\t"\
+                          << #K << ": " << BSLIM_TESTUTIL_DEBUG_REP(K) << "\n";\
                 aSsErT(1, #X, __LINE__); }
 
 #define BSLIM_TESTUTIL_LOOP4_ASSERT(I,J,K,L,X)                                \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\t"                        \
-                          << #J << ": " << (J) << "\t"                        \
-                          << #K << ": " << (K) << "\t"                        \
-                          << #L << ": " << (L) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\t"\
+                          << #J << ": " << BSLIM_TESTUTIL_DEBUG_REP(J) << "\t"\
+                          << #K << ": " << BSLIM_TESTUTIL_DEBUG_REP(K) << "\t"\
+                          << #L << ": " << BSLIM_TESTUTIL_DEBUG_REP(L) << "\n";\
                 aSsErT(1, #X, __LINE__); }
 
 #define BSLIM_TESTUTIL_LOOP5_ASSERT(I,J,K,L,M,X)                              \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\t"                        \
-                          << #J << ": " << (J) << "\t"                        \
-                          << #K << ": " << (K) << "\t"                        \
-                          << #L << ": " << (L) << "\t"                        \
-                          << #M << ": " << (M) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\t"\
+                          << #J << ": " << BSLIM_TESTUTIL_DEBUG_REP(J) << "\t"\
+                          << #K << ": " << BSLIM_TESTUTIL_DEBUG_REP(K) << "\t"\
+                          << #L << ": " << BSLIM_TESTUTIL_DEBUG_REP(L) << "\t"\
+                          << #M << ": " << BSLIM_TESTUTIL_DEBUG_REP(M) << "\n";\
                aSsErT(1, #X, __LINE__); }
 
 #define BSLIM_TESTUTIL_LOOP6_ASSERT(I,J,K,L,M,N,X)                            \
-    if (!(X)) { bsl::cout << #I << ": " << (I) << "\t"                        \
-                          << #J << ": " << (J) << "\t"                        \
-                          << #K << ": " << (K) << "\t"                        \
-                          << #L << ": " << (L) << "\t"                        \
-                          << #M << ": " << (M) << "\t"                        \
-                          << #N << ": " << (N) << "\n";                       \
+    if (!(X)) { bsl::cout << #I << ": " << BSLIM_TESTUTIL_DEBUG_REP(I) << "\t"\
+                          << #J << ": " << BSLIM_TESTUTIL_DEBUG_REP(J) << "\t"\
+                          << #K << ": " << BSLIM_TESTUTIL_DEBUG_REP(K) << "\t"\
+                          << #L << ": " << BSLIM_TESTUTIL_DEBUG_REP(L) << "\t"\
+                          << #M << ": " << BSLIM_TESTUTIL_DEBUG_REP(M) << "\t"\
+                          << #N << ": " << BSLIM_TESTUTIL_DEBUG_REP(N) << "\n";\
                aSsErT(1, #X, __LINE__); }
 
 // The 'BSLIM_TESTUTIL_EXPAND' macro is required to work around a preprocessor
@@ -222,11 +224,11 @@ BSLS_IDENT("$Id: $")
     // Quote identifier literally.
 
 #define BSLIM_TESTUTIL_P(X)                                                   \
-    bsl::cout << #X " = " << (X) << bsl::endl;
+    bsl::cout << #X " = " << BSLIM_TESTUTIL_DEBUG_REP(X) << bsl::endl;
     // Print identifier and its value.
 
 #define BSLIM_TESTUTIL_P_(X)                                                  \
-    bsl::cout << #X " = " << (X) << ", " << bsl::flush;
+    bsl::cout << #X " = " << BSLIM_TESTUTIL_DEBUG_REP(X) << ", " << bsl::flush;
     // 'P(X)' without '\n'
 
 #define BSLIM_TESTUTIL_L_                                                     \
@@ -277,6 +279,10 @@ struct TestUtil {
 
     static void setFunc(Func func);
         // Set the function to be called by 'callFunc' to the specified 'func'.
+
+    template <class T>
+    static const T& debugRep(const T& arg) { return arg; }
+    static int      debugRep(wchar_t  arg) { return arg; }
 };
 
 }  // close package namespace

--- a/groups/bsl/bslma/bslma_allocatoradaptor.h
+++ b/groups/bsl/bslma/bslma_allocatoradaptor.h
@@ -195,7 +195,12 @@ class AllocatorAdaptor_Imp : public Allocator {
         // Construct a polymorphic wrapper around a copy of the specified
         // 'stla' STL-style allocator.
 
-    //! AllocatorAdaptor_Imp(const AllocatorAdaptor_Imp&);
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    AllocatorAdaptor_Imp(const AllocatorAdaptor_Imp& original) = default;
+        // Create an 'AllocatorAdaptor_Imp' object that can allocate and
+        // deallocate memory as if it were the specified 'original' object.
+#endif
+
 
     virtual ~AllocatorAdaptor_Imp();
         // Destroy this object and the STL-style allocator that it wraps.

--- a/groups/bsl/bslma/bslma_stdallocator.h
+++ b/groups/bsl/bslma/bslma_stdallocator.h
@@ -372,11 +372,9 @@ BSL_OVERRIDES_STD mode"
 #include <bsls_platform.h>
 #include <bsls_util.h>
 
-#include <new>
-
 #include <climits>
-
 #include <cstddef>
+#include <new>
 
 namespace bsl {
 
@@ -866,33 +864,37 @@ struct allocator_traits<allocator<TYPE> > {
     // 'allocator_traits' class template for 'bsl::allocator'.
 
     // PUBLIC TYPES
-    typedef allocator<TYPE>                           allocator_type;
-    typedef typename allocator<TYPE>::value_type      value_type;
+    typedef allocator<TYPE> allocator_type;
+    typedef TYPE            value_type;
 
-    typedef typename allocator<TYPE>::pointer         pointer;
-    typedef typename allocator<TYPE>::const_pointer   const_pointer;
-    typedef void                                     *void_pointer;
-    typedef void const                               *const_void_pointer;
-    typedef typename allocator<TYPE>::difference_type difference_type;
-    typedef typename allocator<TYPE>::size_type       size_type;
+    typedef TYPE           *pointer;
+    typedef TYPE const     *const_pointer;
+    typedef void           *void_pointer;
+    typedef void const     *const_void_pointer;
+    typedef std::ptrdiff_t  difference_type;
+    typedef std::size_t     size_type;
 
 #ifdef BSLS_COMPILERFEATURES_SUPPORT_ALIAS_TEMPLATES
     template <class ELEMENT_TYPE>
-    using rebind_alloc =
-        typename allocator<TYPE>::template rebind<ELEMENT_TYPE>::other;
+    using rebind_alloc = allocator<ELEMENT_TYPE>;
 
     template <class ELEMENT_TYPE>
-    using rebind_traits = allocator_traits<rebind_alloc<ELEMENT_TYPE>>;
+    using rebind_traits = allocator_traits<allocator<ELEMENT_TYPE> >;
 #else
     template <class ELEMENT_TYPE>
-    struct rebind_alloc
-        : allocator<TYPE>::template rebind<ELEMENT_TYPE>::other
-    { };
+    struct rebind_alloc : allocator<ELEMENT_TYPE> {
+        rebind_alloc() : allocator<ELEMENT_TYPE>() {}
+
+        template <class OTHER_ALLOC>
+        rebind_alloc(const allocator<OTHER_ALLOC>& other)
+            : allocator<ELEMENT_TYPE>(other)
+        {
+        }
+    };
 
     template <class ELEMENT_TYPE>
     struct rebind_traits
-        : allocator_traits<
-              typename allocator<TYPE>::template rebind<ELEMENT_TYPE>::other>
+        : allocator_traits<allocator<ELEMENT_TYPE> >
     {
     };
 #endif

--- a/groups/bsl/bslmf/bslmf_matchanytype.h
+++ b/groups/bsl/bslmf/bslmf_matchanytype.h
@@ -92,9 +92,11 @@ BSLS_IDENT("$Id: $")
 
 #include <bslscm_version.h>
 
+#include <bslmf_addlvaluereference.h>
 #include <bslmf_addrvaluereference.h>
 
 #include <bsls_compilerfeatures.h>
+#include <bsls_keyword.h>
 #include <bsls_platform.h>
 
 namespace BloombergLP {
@@ -158,6 +160,23 @@ struct TypeRep<TYPE&> {
 #endif
 
 }  // close package namespace
+}  // close enterprise namespace
+
+namespace bsl {
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES)
+template <class TYPE>
+typename add_rvalue_reference<TYPE>::type declval() BSLS_KEYWORD_NOEXCEPT;
+        // Provide a reference to a 'TYPE' object.  This function has no body
+        // and must never be called at run time.  Thus, it does not matter if
+        // 'TYPE' has a default constructor or not.
+#else
+template <class TYPE>
+typename add_lvalue_reference<TYPE>::type declval() BSLS_KEYWORD_NOEXCEPT;
+        // Provide a reference to a 'TYPE' object.  This function has no body
+        // and must never be called at run time.  Thus, it does not matter if
+        // 'TYPE' has a default constructor or not.
+#endif
+}  // close namespace bsl
 
 #ifndef BDE_OPENSOURCE_PUBLICATION  // BACKWARD_COMPATIBILITY
 // ============================================================================
@@ -170,11 +189,11 @@ struct TypeRep<TYPE&> {
 #define bslmf_TypeRep bslmf::TypeRep
     // This alias is defined for backward compatibility.
 
+namespace BloombergLP {
 typedef bslmf::MatchAnyType bslmf_AnyType;
     // This alias is defined for backward compatibility.
-#endif  // BDE_OPENSOURCE_PUBLICATION -- BACKWARD_COMPATIBILITY
-
 }  // close enterprise namespace
+#endif  // BDE_OPENSOURCE_PUBLICATION -- BACKWARD_COMPATIBILITY
 
 #endif
 

--- a/groups/bsl/bslmt/bslmt_turnstile.cpp
+++ b/groups/bsl/bslmt/bslmt_turnstile.cpp
@@ -35,7 +35,7 @@ void bslmt::Turnstile::reset(double                    rate,
                              const bsls::TimeInterval& startTime,
                              const bsls::TimeInterval& minTimeToCallSleep)
 {
-    d_interval  = static_cast<Int64>(k_MICROSECS_PER_SECOND / rate);
+    d_interval  = static_cast<Int64>(+k_MICROSECS_PER_SECOND / rate);
     d_timestamp = bsls::SystemTime::nowMonotonicClock().totalMicroseconds();
     d_nextTurn  = d_timestamp + startTime.totalMicroseconds();
 

--- a/groups/bsl/bsls/bsls_compilerfeatures.h
+++ b/groups/bsl/bsls/bsls_compilerfeatures.h
@@ -801,7 +801,10 @@ BSLS_IDENT("$Id: $")
 // as bugs compared to the final standard.  Therefore, BDE does not attempt to
 // support C++11 in GCC compilers prior to the 4.8 release.
 #if defined(BSLS_PLATFORM_CMP_GNU)
-# define BSLS_COMPILERFEATURES_INITIALIZER_LIST_LEAKS_ON_EXCEPTIONS 1
+
+# if BSLS_PLATFORM_CMP_VERSION < 110000
+#   define BSLS_COMPILERFEATURES_INITIALIZER_LIST_LEAKS_ON_EXCEPTIONS 1
+# endif
 
 # define BSLS_COMPILERFEATURES_SUPPORT_INCLUDE_NEXT
 

--- a/groups/bsl/bsls/bsls_compilerfeatures.t.cpp
+++ b/groups/bsl/bsls/bsls_compilerfeatures.t.cpp
@@ -881,12 +881,14 @@ void runTest() {
         const MyWrapper X = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         (void)X;
     }
-    catch(int) {
+    catch(int count) {
         if (
-          u_BSLS_COMPILERFEATURES_INITIALIZER_LIST_LEAKS_ON_EXCEPTIONS_defined)
-            ASSERT(0 != MyType::s_liveCount);
-        else
-            ASSERT(0 == MyType::s_liveCount);
+        u_BSLS_COMPILERFEATURES_INITIALIZER_LIST_LEAKS_ON_EXCEPTIONS_defined) {
+            ASSERTV(count, MyType::s_liveCount, count == MyType::s_liveCount);
+        }
+        else {
+            ASSERTV(count, MyType::s_liveCount, 0 == MyType::s_liveCount);
+        }
     }
 # endif
 }

--- a/groups/bsl/bsls/bsls_libraryfeatures.h
+++ b/groups/bsl/bsls/bsls_libraryfeatures.h
@@ -1041,8 +1041,8 @@ BSLS_IDENT("$Id: $")
            (defined(__GXX_EXPERIMENTAL_CXX0X__) &&                            \
             BSLS_PLATFORM_CMP_VERSION >= 40800) ||                            \
             (defined(_GLIBCXX_USE_C99) && _GLIBCXX_USE_C99 == 1)
-        // snprintf is also available in C++03 builds with new gcc versions
 
+         // snprintf is also available in C++03 builds with new gcc versions
         #define BSLS_LIBRARYFEATURES_HAS_C99_SNPRINTF                 1
     #endif
     #if defined(__GXX_EXPERIMENTAL_CXX0X__) && (__cplusplus >= 201103L)

--- a/groups/bsl/bslstl/bslstl_allocatortraits.t.cpp
+++ b/groups/bsl/bslstl/bslstl_allocatortraits.t.cpp
@@ -2008,7 +2008,8 @@ int main(int argc, char *argv[])
 
 #define TEST_MAX_SIZE(ALLOC) {                                              \
             ALLOC a;                                                        \
-            ASSERT(allocator_traits<ALLOC >::max_size(a) == a.max_size());  \
+            ASSERTV(allocator_traits<ALLOC >::max_size(a),   a.max_size(),  \
+                    allocator_traits<ALLOC >::max_size(a) == a.max_size()); \
         }
 
         typedef AttribClass5Alloc<NonBslmaAllocator<int> > AC5AllocNonBslma;

--- a/groups/bsl/bslstl/bslstl_bitset.h
+++ b/groups/bsl/bslstl/bslstl_bitset.h
@@ -325,6 +325,13 @@ class bitset :
             // 'bsl::bitset'.
 
       public:
+        // CREATORS
+ #if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+        reference(const reference& original) BSLS_KEYWORD_NOEXCEPT = default;
+            // Create a 'reference' object that refers to the same bit in the
+            // same bitset as the specified 'original'.
+#endif
+
         // MANIPULATORS
         reference& operator=(bool x) BSLS_KEYWORD_NOEXCEPT;
             // Assign to the bit referenced by this object the specified value

--- a/groups/bsl/bslstl/bslstl_pair.t.cpp
+++ b/groups/bsl/bslstl/bslstl_pair.t.cpp
@@ -281,7 +281,9 @@ class Base {
     Base(const Base& original) :d_data(original.d_data) {}
 
     //! ~Base() = default;
-    //! Base& operator=(const Base&) = default;
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    Base& operator=(const Base&) = default;
+#endif
 
     // ACCESSORS
     operator int() const { return d_data; }
@@ -370,7 +372,10 @@ class Node {
     Node(const Node& original) :d_data(original.d_data) {}
 
     //! ~Node() = default;
-    //! Node& operator=(const Node&) = default;
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    Node& operator=(const Node&) = default;
+#endif
+
 
     // ACCESSORS
     int data() const { return d_data; }
@@ -2328,7 +2333,9 @@ class my_NoAllocString : public my_AllocArgString<bsl::allocator<char> >
         // bslstl_pair attempted to construct a 'my_NoAllocString' incorrectly.
 
     //! ~my_NoAllocString() = default;
-    //! my_NoAllocString& operator=(const my_NoAllocString& rhs) = default;
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    my_NoAllocString& operator=(const my_NoAllocString& rhs) = default;
+#endif
 };
 
 my_NoAllocString::my_NoAllocString()

--- a/groups/bsl/bslstl/bslstl_priorityqueue.t.cpp
+++ b/groups/bsl/bslstl/bslstl_priorityqueue.t.cpp
@@ -370,6 +370,10 @@ class NonAllocContainer
     : d_vector(&bslma::MallocFreeAllocator::singleton())
     {}
 
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    NonAllocContainer(const NonAllocContainer& other) = default;
+#endif
+
     ~NonAllocContainer()
         // Destroy this object.
     {}
@@ -2117,7 +2121,7 @@ void TestDriver<VALUE, CONTAINER, COMPARATOR>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -3291,7 +3295,7 @@ void TestDriver<VALUE, CONTAINER, COMPARATOR>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -3694,7 +3698,7 @@ void TestDriver<VALUE, CONTAINER, COMPARATOR>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -4184,7 +4188,7 @@ void TestDriver<VALUE, CONTAINER, COMPARATOR>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     for (int ti = 0; ti < NUM_SPECS; ++ti) {
         const char *const SPEC   = SPECS[ti];
@@ -4319,8 +4323,7 @@ void TestDriver<VALUE, CONTAINER, COMPARATOR>::
             "BC",
             "CDE",
         };
-        const int NUM_SPECS =
-                          static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+        const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
         for (int ti = 0; ti < NUM_SPECS; ++ti) {
             const char *const SPEC   = SPECS[ti];

--- a/groups/bsl/bslstl/bslstl_queue.t.cpp
+++ b/groups/bsl/bslstl/bslstl_queue.t.cpp
@@ -2568,7 +2568,7 @@ void TestDriver<VALUE, CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -3762,7 +3762,7 @@ void TestDriver<VALUE, CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -4170,7 +4170,7 @@ void TestDriver<VALUE, CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -4671,7 +4671,7 @@ void TestDriver<VALUE, CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     for (int ti = 0; ti < NUM_SPECS; ++ti) {
         const char *const SPEC   = SPECS[ti];
@@ -4806,8 +4806,7 @@ void TestDriver<VALUE, CONTAINER>::
             "BC",
             "CDE",
         };
-        const int NUM_SPECS =
-                          static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+        const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
         for (int ti = 0; ti < NUM_SPECS; ++ti) {
             const char *const SPEC   = SPECS[ti];

--- a/groups/bsl/bslstl/bslstl_stack.t.cpp
+++ b/groups/bsl/bslstl/bslstl_stack.t.cpp
@@ -3,10 +3,7 @@
 
 #include <bslstl_vector.h>
 
-#include <bsltf_stdstatefulallocator.h>
-#include <bsltf_stdtestallocator.h>
-#include <bsltf_templatetestfacility.h>
-#include <bsltf_testvaluesarray.h>
+#include <bslalg_rangecompare.h>
 
 #include <bslma_allocator.h>
 #include <bslma_default.h>
@@ -14,8 +11,6 @@
 #include <bslma_mallocfreeallocator.h>
 #include <bslma_testallocator.h>
 #include <bslma_testallocatormonitor.h>
-
-#include <bslalg_rangecompare.h>
 
 #include <bslmf_issame.h>
 #include <bslmf_haspointersemantics.h>
@@ -27,6 +22,11 @@
 #include <bsls_compilerfeatures.h>
 #include <bsls_nameof.h>
 #include <bsls_platform.h>
+
+#include <bsltf_stdstatefulallocator.h>
+#include <bsltf_stdtestallocator.h>
+#include <bsltf_templatetestfacility.h>
+#include <bsltf_testvaluesarray.h>
 
 #include <algorithm>
 #include <functional>
@@ -357,6 +357,10 @@ struct NonAllocCont {
   public:
     // CREATORS
     NonAllocCont() : d_vector(&bslma::MallocFreeAllocator::singleton()) {}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_DEFAULTED_FUNCTIONS)
+    NonAllocCont(const NonAllocCont& other) = default;
+#endif
 
     ~NonAllocCont() {}
 
@@ -3018,7 +3022,7 @@ void TestDriver<CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -4052,7 +4056,7 @@ void TestDriver<CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -4479,7 +4483,7 @@ void TestDriver<CONTAINER>::testCase8_propagate_on_container_swap_dispatch()
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     bslma::TestAllocator da("default", veryVeryVeryVerbose);
     bslma::DefaultAllocatorGuard dag(&da);
@@ -5039,7 +5043,7 @@ void TestDriver<CONTAINER>::
         "BC",
         "CDE",
     };
-    const int NUM_SPECS = static_cast<const int>(sizeof SPECS / sizeof *SPECS);
+    const int NUM_SPECS = static_cast<int>(sizeof SPECS / sizeof *SPECS);
 
     for (int ti = 0; ti < NUM_SPECS; ++ti) {
         const char *const SPEC   = SPECS[ti];

--- a/groups/bsl/bslstl/bslstl_string.h
+++ b/groups/bsl/bslstl/bslstl_string.h
@@ -1054,7 +1054,7 @@ class basic_string
 
   private:
     // PRIVATE TYPES
-    typedef String_Imp<CHAR_TYPE, typename ALLOCATOR::size_type> Imp;
+    typedef String_Imp<CHAR_TYPE, size_type>                     Imp;
 
     typedef BloombergLP::bslalg::ContainerBase<ALLOCATOR>        ContainerBase;
 
@@ -5385,7 +5385,7 @@ basic_string<CHAR_TYPE,CHAR_TRAITS,ALLOCATOR>::max_size() const
     // Must take into account the null-terminating character.
 
     size_type stringMaxSize = ~size_type(0) / sizeof(CHAR_TYPE) - 1;
-    size_type allocMaxSize  = get_allocator().max_size() - 1;
+    size_type allocMaxSize  = AllocatorTraits::max_size(get_allocator()) - 1;
     return allocMaxSize < stringMaxSize ? allocMaxSize : stringMaxSize;
 }
 

--- a/groups/bsl/bsltf/bsltf_allocargumenttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_allocargumenttype.t.cpp
@@ -857,7 +857,7 @@ int main(int argc, char *argv[])
                     othAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   }
                 }
 
@@ -881,7 +881,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(MoveUtil::move(mZ), &za);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     // Note that move-constructing from a default-constructed
@@ -980,7 +980,7 @@ int main(int argc, char *argv[])
                         othAllocatorPtr = &da;
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       }
                     }
 
@@ -1006,7 +1006,8 @@ int main(int argc, char *argv[])
                             objPtr = new (fa) Obj(MoveUtil::move(mZ), &za);
                           } break;
                           default: {
-                            ASSERTV(CONFIG, !"Bad allocator config.");
+                            BSLS_ASSERT_INVOKE_NORETURN(
+					              "Bad allocator config.");
                           } break;
                         }
                         ASSERTV(CONFIG, (&sa != &oa) == tam.isInUseUp());
@@ -1482,7 +1483,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -1504,7 +1505,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1731,7 +1732,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1753,7 +1754,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(VALUE, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1907,7 +1908,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1929,7 +1930,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG,  tam.isInUseSame());

--- a/groups/bsl/bsltf/bsltf_allocbitwisemoveabletesttype.h
+++ b/groups/bsl/bsltf/bsltf_allocbitwisemoveabletesttype.h
@@ -92,10 +92,10 @@ class AllocBitwiseMoveableTestType {
     // class attributes.
 
     // DATA
-    int             *d_data_p;       // pointer to the integer class value
+    int              *d_data_p;       // pointer to the integer class value
 
     bslma::Allocator *d_allocator_p;  // allocator used to supply memory (held,
-                                     // not owned)
+                                      // not owned)
 
   public:
     // CREATORS

--- a/groups/bsl/bsltf/bsltf_allocbitwisemoveabletesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_allocbitwisemoveabletesttype.t.cpp
@@ -658,7 +658,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -680,7 +680,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1059,7 +1059,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -1081,7 +1081,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1249,7 +1249,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1271,7 +1271,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_allocemplacabletesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_allocemplacabletesttype.t.cpp
@@ -1278,7 +1278,7 @@ void TestDriver::testCase7()
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } break;
             }
 
@@ -1300,7 +1300,7 @@ void TestDriver::testCase7()
                     objPtr = new (fa) Obj(Z, &sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
             } BSLMA_TESTALLOCATOR_EXCEPTION_TEST_END;
@@ -1636,7 +1636,7 @@ void TestDriver::testCase4()
                         objAllocatorPtr = &sa;
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
 
@@ -1831,7 +1831,7 @@ void TestDriver::testCase4()
                         }
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
 
@@ -2039,7 +2039,7 @@ void TestDriver::testCase2a()
             objAllocator = &ta;
           } break;
           default: {
-            ASSERTV(!"Invalid allocator config!");
+            BSLS_ASSERT_INVOKE_NORETURN("Invalid allocator config!");
           } break;
         }
         bslma::TestAllocator& oa = *objAllocator;
@@ -2215,7 +2215,7 @@ void TestDriver::testCase2a()
                                  &oa);
               } break;
               default: {
-                ASSERTV(!"Invalid # of args!");
+                BSLS_ASSERT_INVOKE_NORETURN("Invalid # of args!");
               } break;
             }
 
@@ -2496,7 +2496,7 @@ void TestDriver::testCase2()
                                  testArg(A14, MOVE_14));
               } break;
               default: {
-                ASSERTV(!"Invalid # of args!");
+                BSLS_ASSERT_INVOKE_NORETURN("Invalid # of args!");
               } break;
             }
             objAllocator = da;
@@ -2653,13 +2653,13 @@ void TestDriver::testCase2()
                                  &ta);
               } break;
               default: {
-                ASSERTV(!"Invalid # of args!");
+                BSLS_ASSERT_INVOKE_NORETURN("Invalid # of args!");
               } break;
             }
             objAllocator = &ta;
           } break;
           default: {
-            ASSERTV(!"Invalid config spec!");
+            BSLS_ASSERT_INVOKE_NORETURN("Invalid config spec!");
           }
         }
         bslma::DestructorGuard<Obj> guard(&buffer.object());

--- a/groups/bsl/bsltf/bsltf_alloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_alloctesttype.t.cpp
@@ -800,7 +800,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -822,7 +822,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1200,7 +1200,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1222,7 +1222,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1390,7 +1390,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1412,7 +1412,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_movablealloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_movablealloctesttype.t.cpp
@@ -803,7 +803,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -825,7 +825,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1213,7 +1213,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1235,7 +1235,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1403,7 +1403,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1425,7 +1425,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG,  tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_moveonlyalloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_moveonlyalloctesttype.t.cpp
@@ -984,7 +984,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -1008,7 +1008,7 @@ int main(int argc, char *argv[])
                                               &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, (&sa != &oa) == tam.isInUseUp());
@@ -1417,7 +1417,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1439,7 +1439,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1612,7 +1612,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1634,7 +1634,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_nonoptionalalloctesttype.t.cpp
@@ -798,7 +798,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -820,7 +820,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1188,7 +1188,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1207,7 +1207,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1373,7 +1373,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1392,7 +1392,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_stdallocatoradaptor.t.cpp
+++ b/groups/bsl/bsltf/bsltf_stdallocatoradaptor.t.cpp
@@ -821,7 +821,7 @@ void testCase4_RunTest()
                            testArg(B10, MOVE_10));
       } break;
       default: {
-        ASSERTV(!"Invalid # of args!");
+        BSLS_ASSERT_INVOKE_NORETURN("Invalid # of args!");
       } break;
     }
 
@@ -1707,7 +1707,7 @@ int main(int argc, char *argv[])
                 printf("\tTesting construction from another type adapter.\n");
               } break;
               default: {
-                  ASSERTV(CONFIG, !"Bad constructor config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad constructor config.");
               } break;
             }
             // Test allocators.
@@ -1758,7 +1758,7 @@ int main(int argc, char *argv[])
                 expected = &ANOTHER;
               } break;
               default: {
-                  ASSERTV(CONFIG, !"Bad constructor config.");
+                  BSLS_ASSERT_INVOKE_NORETURN("Bad constructor config.");
               } break;
             }
 

--- a/groups/bsl/bsltf/bsltf_stdalloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_stdalloctesttype.t.cpp
@@ -802,7 +802,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -824,7 +824,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(Z, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1201,7 +1201,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1223,7 +1223,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1392,7 +1392,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1414,7 +1414,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());

--- a/groups/bsl/bsltf/bsltf_stdstatefulallocator.t.cpp
+++ b/groups/bsl/bsltf/bsltf_stdstatefulallocator.t.cpp
@@ -492,7 +492,7 @@ void TestDriver<VALUE>::testCase15_RunTest(Obj *object)
                           testArg(A10, MOVE_10));
       } break;
       default: {
-        ASSERTV(!"Invalid # of args!");
+        BSLS_ASSERT_INVOKE_NORETURN("Invalid # of args!");
       } break;
     }
 

--- a/groups/bsl/bsltf/bsltf_testvaluesarray.t.cpp
+++ b/groups/bsl/bsltf/bsltf_testvaluesarray.t.cpp
@@ -1980,7 +1980,7 @@ void TestDriver<VALUE, ALLOCATOR, CONVERTER>::testCase5()
                 objPtr = new (foa) Obj(sa);
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad constructor config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad constructor config.");
                 return;                                               // RETURN
               } break;
             }
@@ -2227,7 +2227,7 @@ void TestDriver<VALUE, ALLOCATOR, CONVERTER>::testCase3()
                     objPtr = new (foa) Obj(SPEC, sa);
                   } break;
                   default: {
-                    ASSERTV(LINE, CONFIG, !"Bad constructor config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad constructor config.");
                     return;                                           // RETURN
                   } break;
                 }

--- a/groups/bsl/bsltf/bsltf_wellbehavedmoveonlyalloctesttype.t.cpp
+++ b/groups/bsl/bsltf/bsltf_wellbehavedmoveonlyalloctesttype.t.cpp
@@ -1127,7 +1127,7 @@ int main(int argc, char *argv[])
                     allocMatch = false;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } break;
                 }
 
@@ -1154,7 +1154,7 @@ int main(int argc, char *argv[])
                                               &ta);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } break;
                     }
                     ASSERTV(CONFIG, (&sa != &oa) == tam.isInUseUp());
@@ -1555,7 +1555,7 @@ int main(int argc, char *argv[])
                     objAllocatorPtr = &sa;
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
 
@@ -1577,7 +1577,7 @@ int main(int argc, char *argv[])
                         objPtr = new (fa) Obj(DATA, &sa);
                       } break;
                       default: {
-                        ASSERTV(CONFIG, !"Bad allocator config.");
+                        BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                       } return testStatus;                            // RETURN
                     }
                     ASSERTV(CONFIG, tam.isInUseUp());
@@ -1750,7 +1750,7 @@ int main(int argc, char *argv[])
                 objAllocatorPtr = &sa;
               } break;
               default: {
-                ASSERTV(CONFIG, !"Bad allocator config.");
+                BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
               } return testStatus;                                    // RETURN
             }
 
@@ -1772,7 +1772,7 @@ int main(int argc, char *argv[])
                     objPtr = new (fa) Obj(&sa);
                   } break;
                   default: {
-                    ASSERTV(CONFIG, !"Bad allocator config.");
+                    BSLS_ASSERT_INVOKE_NORETURN("Bad allocator config.");
                   } return testStatus;                                // RETURN
                 }
                 ASSERTV(CONFIG, tam.isInUseUp());


### PR DESCRIPTION
This patch does not attend to many new C++20 warnings, but
deals with new compilation failures, mostly arising from
an incomplete implementation and adoption of allocator
traits in our original C++11 port, and new errors using
narrow character iostreams with wchar_t data.  Most of the
changes affect test drivers only.

It does deal with the deprecation of some operations with
enums, but not other C++20 deprecations such as some
uses of volatile.