### PR TITLE
Don't rely on implicit conversion from std::string_view to std::string

### DIFF
--- a/groups/bdl/bdls/bdls_filesystemutil.cpp
+++ b/groups/bdl/bdls/bdls_filesystemutil.cpp
@@ -1247,7 +1247,7 @@ int FilesystemUtil::visitPaths(
     if (bsl::string::npos != dirName.find_first_of("*?")) {
         bsl::vector<bsl::string> leaves;
         bsl::vector<bsl::string> paths, workingPaths;
-        bsl::string pattern = patternSV;
+        bsl::string pattern(patternSV.data(), patternSV.size());
         while (PathUtil::hasLeaf(pattern)) {
             leaves.push_back(bsl::string());
             if (0 != PathUtil::getLeaf(&leaves.back(), pattern)) {


### PR DESCRIPTION
**Describe your changes**
Implicit conversion from `std::string_view` to `std::string` appears not to be the standard but is implemented in most standard libraries. The issue was found building bde on Windows using clang.

**Testing performed**
Build completes successfully.
