### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,20 @@ The following commands can be used to configure and build the BDE repository:
    $ cmake_build.py build --test run
    ```
 
+Build Instructions (Vcpkg)
+---------------------------------
+You can build and install bde using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```sh or powershell
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install bde
+```
+
+The bde port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 License
 =======
 The BDE libraries are distributed under the Apache License (version 2.0); see


### PR DESCRIPTION
`bde` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `bde` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `bde`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/bde/portfile.cmake). We try to keep the library maintained as close as possible to the original library.😊