### PR TITLE
bslma_memoryresource: Fix documentation rendering

### DIFF
--- a/groups/bsl/bslma/bslma_memoryresource.h
+++ b/groups/bsl/bslma/bslma_memoryresource.h
@@ -412,7 +412,7 @@ class memory_resource {
 
     // MANIPULATORS
     //! memory_resource& operator=(const memory_resource&)
-    //                                                    BSLS_KEYWORD_DEFAULT;
+    //!                                                   BSLS_KEYWORD_DEFAULT;
         // Return a modifiable reference to this object.
 
     BSLS_ANNOTATION_NODISCARD


### PR DESCRIPTION
On the generated documentation, the allocate() member has been combined on the same line as the assignment operator. I suspect this missing `//!` fixes it.
