### PR TITLE
Remove mention of PooledBufferChain from docs

### DIFF
--- a/groups/bdl/bdlbb/bdlbb_blob.h
+++ b/groups/bdl/bdlbb/bdlbb_blob.h
@@ -53,16 +53,11 @@ BSLS_IDENT("$Id: $")
 // This design is intended to allow very efficient re-assignment of buffers (or
 // part of buffers using shared pointer aliasing) between different blobs,
 // without copying of the underlying data, while promoting efficient allocation
-// of resources (via retaining capacity).  Thus, `bdlbb::Blob` is an
-// advantageous replacement for `bdlbb::PooledBufferChain` when manipulation of
-// the sequence, sharing of portions of the sequence, and lifetime management
-// of individual portions of the sequence, are desired.  Another added
-// flexibility of `bdlbb::Blob` is the possibility for buffers in the sequence
-// to have different sizes (as opposed to a uniform fixed size for
-// `bdlbb::PooledBufferChain`).  When choosing whether to use a `bdlbb::Blob`
-// vs. a `bdlbb::PooledBufferChain`, one must consider the added flexibility
-// versus the added cost of shared ownership for each individual buffer and
-// random access to the buffer.
+// of resources (via retaining capacity).  `bdlbb::Blob` is an advantageous
+// choice when manipulation of the sequence, sharing of portions of the
+// sequence, lifetime management of individual portions of the sequence, and
+// the possibility of buffers in the sequence to have different sizes, are
+// desired.
 //
 ///Thread Safety
 ///-------------


### PR DESCRIPTION
The documentation for bdlbb_blob mentioned bdlbb::PooledBufferChain, which does not exist.  It's likely a translated reference to [bdlmca::PooledBufferChain][1], which was [deleted in 2015][2].

[1]: https://github.com/bloomberg/bde/blob/fdfc08ade1491a860d46be7e1584b88e0971c21a/groups/bdl/bdlmca/bdlmca_xxxpooledbufferchain.h
[2]: https://github.com/bloomberg/bde/commit/fafb5df12d43cb6f6462220abe83805d5a780502#diff-840048b663e0d1f02aaaf0feed16db938fa1d2d59615d123fae90982939ad783

-------------------------------

**Describe your changes**
I was reading `bdlbb` as a reference for a side project, and I noticed this mention of a missing component.

Here's how I went looking:
```console
david@dell:~/src/bde$ git grep -i 'pooled.\?buffer.\?chain'
groups/bdl/bdlbb/bdlbb_blob.h:// advantageous replacement for `bdlbb::PooledBufferChain` when manipulation of
groups/bdl/bdlbb/bdlbb_blob.h:// `bdlbb::PooledBufferChain`).  When choosing whether to use a `bdlbb::Blob`
groups/bdl/bdlbb/bdlbb_blob.h:// vs. a `bdlbb::PooledBufferChain`, one must consider the added flexibility
```

It might be better to remove that entire paragraph rather than revise it the way I have. Up to you.
