### PR TITLE
fix clang compatiblity when building with gcc

### DIFF
--- a/groups/bdl/bdlt/bdlt_datetime.cpp
+++ b/groups/bdl/bdlt/bdlt_datetime.cpp
@@ -183,6 +183,19 @@ bsl::ostream& Datetime::print(bsl::ostream& stream,
     return stream;
 }
 
+bool Datetime::validateAndTraceLogRepresentation() const
+{
+    if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(k_REP_MASK <= d_value)) {
+        return true;                                                  // RETURN
+    }
+    BSLS_ASSERT_SAFE(
+                 0 && "detected invalid 'bdlt::Datetime'; see TEAM 579660115");
+    BSLS_REVIEW_INVOKE(
+                      "detected invalid 'bdlt::Datetime'; see TEAM 579660115");
+
+    return false;
+}
+
 int Datetime::printToBuffer(char *result,
                             int   numBytes,
                             int   fractionalSecondPrecision) const

--- a/groups/bdl/bdlt/bdlt_datetime.h
+++ b/groups/bdl/bdlt/bdlt_datetime.h
@@ -1125,20 +1125,6 @@ bsls::Types::Uint64 Datetime::updatedRepresentation() const
          | k_REP_MASK;
 }
 
-inline
-bool Datetime::validateAndTraceLogRepresentation() const
-{
-    if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(k_REP_MASK <= d_value)) {
-        return true;                                                  // RETURN
-    }
-    BSLS_ASSERT_SAFE(
-                 0 && "detected invalid 'bdlt::Datetime'; see TEAM 579660115");
-    BSLS_REVIEW_INVOKE(
-                      "detected invalid 'bdlt::Datetime'; see TEAM 579660115");
-
-    return false;
-}
-
 // CLASS METHODS
 inline
 bool Datetime::isValid(int year,


### PR DESCRIPTION
Fixes https://github.com/bloomberg/bde/issues/301

**Describe your changes**
Just moves calls from header to source

**Testing performed**
Built with vcpkg and then linked used clang
